### PR TITLE
fix: drop node 10 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.0.x, 12.x, 14.0.x, 14.x, 15.x, 16.x]
+        node-version: [12.13.0, 12.x, 14.15.0, 14.x, 16.x]
         platform:
         - os: ubuntu-latest
           shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10.0.x, 10.x, 12.0.x, 12.x, 14.0.x, 14.x, 15.x, 16.x]
+        node-version: [12.0.x, 12.x, 14.0.x, 14.x, 15.x, 16.x]
         platform:
         - os: ubuntu-latest
           shell: bash

--- a/lib/content/ci.yml
+++ b/lib/content/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.0.x, 12.x, 14.0.x, 14.x, 15.x, 16.x]
+        node-version: [12.13.0, 12.x, 14.15.0, 14.x, 16.x]
         platform:
         - os: ubuntu-latest
           shell: bash

--- a/lib/content/ci.yml
+++ b/lib/content/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [10.0.x, 10.x, 12.0.x, 12.x, 14.0.x, 14.x, 15.x, 16.x]
+        node-version: [12.0.x, 12.x, 14.0.x, 14.x, 15.x, 16.x]
         platform:
         - os: ubuntu-latest
           shell: bash

--- a/lib/package.js
+++ b/lib/package.js
@@ -19,7 +19,7 @@ const changes = {
     posttest: 'npm run lint',
   },
   engines: {
-    node: '>=12',
+    node: '^12.13.0 || ^14.15.0 || >=16',
   },
 }
 

--- a/lib/package.js
+++ b/lib/package.js
@@ -18,6 +18,9 @@ const changes = {
     test: 'tap',
     posttest: 'npm run lint',
   },
+  engines: {
+    node: '>=12',
+  },
 }
 
 const patchPackage = async (root) => {

--- a/package.json
+++ b/package.json
@@ -7,17 +7,17 @@
     "npm-template-check": "bin/npm-template-check.js"
   },
   "scripts": {
-    "prelint": "ln -sf ../../bin/npm-template-check.js node_modules/.bin/npm-template-check",
     "lint": "eslint '**/*.js'",
-    "postlint": "npm-template-check",
     "lintfix": "npm run lint -- --fix",
-    "preversion": "npm test",
-    "postversion": "npm publish",
-    "prepublishOnly": "git push origin --follow-tags",
-    "snap": "tap",
-    "test": "tap",
+    "postinstall": "node bin/postinstall.js",
+    "postlint": "npm-template-check",
     "posttest": "npm run lint",
-    "postinstall": "node bin/postinstall.js"
+    "postversion": "npm publish",
+    "prelint": "ln -sf ../../bin/npm-template-check.js node_modules/.bin/npm-template-check",
+    "prepublishOnly": "git push origin --follow-tags",
+    "preversion": "npm test",
+    "snap": "tap",
+    "test": "tap"
   },
   "repository": {
     "type": "git",
@@ -50,6 +50,6 @@
   },
   "templateVersion": "1.0.3",
   "engines": {
-    "node": ">=12"
+    "node": "^12.13.0 || ^14.15.0 || >=16"
   }
 }

--- a/package.json
+++ b/package.json
@@ -48,5 +48,8 @@
     "@npmcli/eslint-config": "^1.0.0",
     "tap": "^15.0.9"
   },
-  "templateVersion": "1.0.3"
+  "templateVersion": "1.0.3",
+  "engines": {
+    "node": ">=12"
+  }
 }


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
This both removes node 10.0.x and 10.x from the testing matrix, and adds a node engine requirement of `>=12`

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
