### PR TITLE
feat: add 16.13.0 as an explicit node version to test

### DIFF
--- a/lib/content/ci.yml
+++ b/lib/content/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [12.13.0, 12.x, 14.15.0, 14.x, 16.x]
+        node-version: [12.13.0, 12.x, 14.15.0, 14.x, 16.13.0, 16.x]
         platform:
         - os: ubuntu-latest
           shell: bash


### PR DESCRIPTION
Node 16.13.0 marks the transition of 16.x into LTS. We want to explicitly test
the major versions of node we support at the release they enter LTS.

Fixes: #8
