### PR TITLE
fix: remove npm ls -a from ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,4 +51,3 @@ jobs:
       - run: npm i --prefer-online -g npm@latest
       - run: npm ci
       - run: npm test --ignore-scripts
-      - run: npm ls -a

--- a/lib/content/ci.yml
+++ b/lib/content/ci.yml
@@ -51,4 +51,3 @@ jobs:
       - run: npm i --prefer-online -g npm@latest
       - run: npm ci
       - run: npm test --ignore-scripts
-      - run: npm ls -a


### PR DESCRIPTION
After some discussion it was decided that this was some legacy behavior
in our testing that isn't very applicable to modules, especially
considering that we are planning on omitting package-locks from the git
repos in the near future.
