### PR TITLE
fix: drop bash and powershell from windows ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,7 @@ jobs:
         - os: macos-latest
           shell: bash
         - os: windows-latest
-          shell: bash
-        - os: windows-latest
           shell: cmd
-        - os: windows-latest
-          shell: powershell
     runs-on: ${{ matrix.platform.os }}
     defaults:
       run:

--- a/lib/content/ci-workspace.yml
+++ b/lib/content/ci-workspace.yml
@@ -45,9 +45,7 @@ jobs:
           - os: macos-latest
             shell: bash
           - os: windows-latest
-            shell: bash
-          - os: windows-latest
-            shell: powershell
+            shell: cmd
 
     runs-on: ${{ matrix.platform.os }}
     defaults:

--- a/lib/content/ci.yml
+++ b/lib/content/ci.yml
@@ -35,11 +35,7 @@ jobs:
         - os: macos-latest
           shell: bash
         - os: windows-latest
-          shell: bash
-        - os: windows-latest
           shell: cmd
-        - os: windows-latest
-          shell: powershell
     runs-on: ${{ matrix.platform.os }}
     defaults:
       run:


### PR DESCRIPTION
we don't actually do anything differently in these shells since we aren't setting the scriptShell so they're all running in cmd.exe anyway
