### PR TITLE
fix: try to workaround old npm not being able to update in windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,18 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm i --prefer-online -g npm@latest
+        # node 12 and 14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update to workable npm (windows)
+        if: matrix.platform.os == 'windows-latest' && (startsWith(matrix.node-version, '12') || startsWith(matrix.node-version, '14'))
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ..\npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+      - name: Update npm
+        run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+      - run: npm -v
       - run: npm i
       - run: npm test --ignore-scripts

--- a/lib/content/ci-workspace.yml
+++ b/lib/content/ci-workspace.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     paths:
       - %%pkgpath%%/**
-    branches:
-      - '*'
   push:
     paths:
       - %%pkgpath%%/**
@@ -20,25 +18,18 @@ jobs:
     steps:
       # Checkout the npm/cli repo
       - uses: actions/checkout@v2
-      - name: Use Node.js 16.x
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
-          node-version: 16.x
-          cache: npm
-      - name: Install dependencies
-        run: |
-          node ./bin/npm-cli.js install --ignore-scripts --no-audit
-          node ./bin/npm-cli.js rebuild
-      - name: Run linting
-        run: node ./bin/npm-cli.js run posttest -w %%pkgpath%%
-        env:
-          DEPLOY_VERSION: testing
+          node-version: '16'
+      - run: npm i --prefer-online -g npm@latest
+      - run: npm i
+      - run: npm run lint -w %%pkgpath%%
 
   test:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['12.13.0', 12.x, '14.15.0', 14.x, '16.0.0', 16.x]
+        node-version: [12.13.0, 12.x, 14.15.0, 14.x, 16.13.0, 16.x]
         platform:
           - os: ubuntu-latest
             shell: bash
@@ -46,29 +37,27 @@ jobs:
             shell: bash
           - os: windows-latest
             shell: cmd
-
     runs-on: ${{ matrix.platform.os }}
     defaults:
       run:
         shell: ${{ matrix.platform.shell }}
-
     steps:
-      # Checkout the npm/cli repo
-    - uses: actions/checkout@v2
-
-      # Installs the specific version of Node.js
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: npm
-
-      # Run the installer script
-    - name: Install dependencies
-      run: |
-        node ./bin/npm-cli.js install --ignore-scripts --no-audit
-        node ./bin/npm-cli.js rebuild
-
-      # Run the tests, but not if we're just gonna do coveralls later anyway
-    - name: Run Tap tests
-      run: node ./bin/npm-cli.js run -w %%pkgpath%% --ignore-scripts test -- -t600 -Rbase -c
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+        # node 12 and 14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update to workable npm (windows)
+        if: matrix.platform.os == 'windows-latest' && (startsWith(matrix.node-version, '12') || startsWith(matrix.node-version, '14'))
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ..\npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+      - name: Update npm
+        run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+      - run: npm -v
+      - run: npm i
+      - run: npm test --ignore-scripts -w %%pkgpath%%

--- a/lib/content/ci.yml
+++ b/lib/content/ci.yml
@@ -45,6 +45,18 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm i --prefer-online -g npm@latest
+        # node 12 and 14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update to workable npm (windows)
+        if: matrix.platform.os == 'windows-latest' && (startsWith(matrix.node-version, '12') || startsWith(matrix.node-version, '14'))
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ..\npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+      - name: Update npm
+        run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+      - run: npm -v
       - run: npm i
       - run: npm test --ignore-scripts


### PR DESCRIPTION
i also brought the `ci-workspaces.yml` in sync with the other workflows, but accounting for the workspace related changes. that probably should've been a separate commit but i got a little carried away..