### PR TITLE
fix: dependabot permissions

### DIFF
--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -5,7 +5,7 @@ on: pull_request
 
 # https://docs.github.com/en/rest/overview/permissions-required-for-github-apps
 permissions:
-  contents: write
+  repo: write
 
 jobs:
   Install:

--- a/lib/content/post-dependabot.yml
+++ b/lib/content/post-dependabot.yml
@@ -5,7 +5,7 @@ on: pull_request
 
 # https://docs.github.com/en/rest/overview/permissions-required-for-github-apps
 permissions:
-  contents: write
+  repo: write
 
 jobs:
   Install:


### PR DESCRIPTION
`repo: write` is the setting, according to folks
