### PR TITLE
feat(eslint): support glob for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ These fields will be set in the project's `package.json`:
   license: 'ISC',
   templateVersion: $TEMPLATE_VERSION,
   scripts: {
-    lint: `eslint '**/*.js'`,
+    lint: 'eslint "**/*.js"',
     postlint: 'npm-template-check',
     lintfix: 'npm run lint -- --fix',
     'template-copy': 'npm-template-copy --force',

--- a/lib/postinstall/update-package.js
+++ b/lib/postinstall/update-package.js
@@ -9,7 +9,7 @@ const changes = {
   author: 'GitHub Inc.',
   files: ['bin', 'lib'],
   scripts: {
-    lint: `eslint '**/*.js'`,
+    lint: 'eslint "**/*.js"',
     postlint: 'npm-template-check',
     'template-copy': 'npm-template-copy --force',
     lintfix: 'npm run lint -- --fix',

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "npm-template-copy": "bin/postinstall.js"
   },
   "scripts": {
-    "lint": "eslint '**/*.js'",
+    "lint": "eslint \"**/*.js\"",
     "lintfix": "npm run lint -- --fix",
     "postinstall": "node bin/postinstall.js",
     "postlint": "npm-template-check",

--- a/tap-snapshots/test/postlint/check-package.js.test.cjs
+++ b/tap-snapshots/test/postlint/check-package.js.test.cjs
@@ -12,7 +12,7 @@ Array [
       The following package.json fields are incorrect:
         Field: "author" Expected: "GitHub Inc." Found: "Bob"
         Field: "files" Expected: ["bin","lib"] Found: undefined
-        Field: "scripts" Expected: {"lint":"eslint '**/*.js'","postlint":"npm-template-check","template-copy":"npm-template-copy --force","lintfix":"npm run lint -- --fix","preversion":"npm test","postversion":"npm publish","prepublishOnly":"git push origin --follow-tags","snap":"tap","test":"tap","posttest":"npm run lint"} Found: undefined
+        Field: "scripts" Expected: {"lint":"eslint \\\\"**/*.js\\\\"","postlint":"npm-template-check","template-copy":"npm-template-copy --force","lintfix":"npm run lint -- --fix","preversion":"npm test","postversion":"npm publish","prepublishOnly":"git push origin --follow-tags","snap":"tap","test":"tap","posttest":"npm run lint"} Found: undefined
         Field: "engines" Expected: {"node":"^12.13.0 || ^14.15.0 || >=16"} Found: undefined
     ),
     "solution": "npm rm @npmcli/template-oss && npm i -D @npmcli/template-oss",
@@ -27,7 +27,7 @@ Array [
       The following package.json fields are incorrect:
         Field: "author" Expected: "GitHub Inc." Found: undefined
         Field: "files" Expected: ["bin","lib"] Found: undefined
-        Field: "scripts.lint" Expected: "eslint '**/*.js'" Found: undefined
+        Field: "scripts.lint" Expected: "eslint \\\\"**/*.js\\\\"" Found: undefined
         Field: "scripts.postlint" Expected: "npm-template-check" Found: undefined
         Field: "scripts.template-copy" Expected: "npm-template-copy --force" Found: undefined
         Field: "scripts.lintfix" Expected: "npm run lint -- --fix" Found: undefined
@@ -51,7 +51,7 @@ Array [
       The following package.json fields are incorrect:
         Field: "author" Expected: "GitHub Inc." Found: undefined
         Field: "files" Expected: ["bin","lib"] Found: undefined
-        Field: "scripts" Expected: {"lint":"eslint '**/*.js'","postlint":"npm-template-check","template-copy":"npm-template-copy --force","lintfix":"npm run lint -- --fix","preversion":"npm test","postversion":"npm publish","prepublishOnly":"git push origin --follow-tags","snap":"tap","test":"tap","posttest":"npm run lint"} Found: undefined
+        Field: "scripts" Expected: {"lint":"eslint \\\\"**/*.js\\\\"","postlint":"npm-template-check","template-copy":"npm-template-copy --force","lintfix":"npm run lint -- --fix","preversion":"npm test","postversion":"npm publish","prepublishOnly":"git push origin --follow-tags","snap":"tap","test":"tap","posttest":"npm run lint"} Found: undefined
         Field: "engines" Expected: {"node":"^12.13.0 || ^14.15.0 || >=16"} Found: undefined
     ),
     "solution": "npm rm @npmcli/template-oss && npm i -D @npmcli/template-oss",
@@ -66,7 +66,7 @@ Array [
       The following package.json fields are incorrect:
         Field: "author" Expected: "GitHub Inc." Found: undefined
         Field: "files" Expected: ["bin","lib"] Found: undefined
-        Field: "scripts" Expected: {"lint":"eslint '**/*.js'","postlint":"npm-template-check","template-copy":"npm-template-copy --force","lintfix":"npm run lint -- --fix","preversion":"npm test","postversion":"npm publish","prepublishOnly":"git push origin --follow-tags","snap":"tap","test":"tap","posttest":"npm run lint"} Found: undefined
+        Field: "scripts" Expected: {"lint":"eslint \\\\"**/*.js\\\\"","postlint":"npm-template-check","template-copy":"npm-template-copy --force","lintfix":"npm run lint -- --fix","preversion":"npm test","postversion":"npm publish","prepublishOnly":"git push origin --follow-tags","snap":"tap","test":"tap","posttest":"npm run lint"} Found: undefined
         Field: "engines" Expected: {"node":"^12.13.0 || ^14.15.0 || >=16"} Found: undefined
     ),
     "solution": "npm rm @npmcli/template-oss && npm i -D @npmcli/template-oss",


### PR DESCRIPTION



<!-- What / Why -->
Currently, the `lint` script will fail on Windows because single quotes are being used to wrap the glob.
This can be easily fixed by using double quotes.

- [x] update snapshots.

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Source: [ESLint CLI doc](https://eslint.org/docs/user-guide/command-line-interface#:~:text=If%20you%20want%20to%20use%20node%20glob%20syntax%2C%20you%20have%20to%20quote%20your%20parameter%20(using%20double%20quotes%20if%20you%20need%20it%20to%20run%20in%20Windows))