### PR TITLE
fix: misc workspace fixes

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,7 @@ const localConfigs = readdir(__dirname)
   .map((file) => `./${file}`)
 
 module.exports = {
+  root: true,
   extends: [
     '@npmcli',
     ...localConfigs,

--- a/lib/apply/apply-files.js
+++ b/lib/apply/apply-files.js
@@ -18,7 +18,7 @@ module.exports = [{
     options.config.repoFiles,
     options
   ),
-  when: ({ config: c }) => c.isForce || (c.needsUpdate && c.applyRepo),
+  when: ({ config: c }) => c.applyRepo && c.needsUpdate,
   name: 'apply-repo',
 }, {
   run: (options) => run(
@@ -26,6 +26,6 @@ module.exports = [{
     options.config.moduleFiles,
     options
   ),
-  when: ({ config: c }) => c.isForce || (c.needsUpdate && c.applyModule),
+  when: ({ config: c }) => c.applyModule && c.needsUpdate,
   name: 'apply-module',
 }]

--- a/lib/apply/apply-version.js
+++ b/lib/apply/apply-version.js
@@ -1,0 +1,26 @@
+const log = require('proc-log')
+const PackageJson = require('@npmcli/package-json')
+
+const run = async ({ config: c }) => {
+  const {
+    moduleDir: dir,
+    __CONFIG_KEY__: key,
+    __VERSION__: version,
+  } = c
+
+  log.verbose('apply-version', dir)
+
+  const pkg = await PackageJson.load(dir)
+  if (!pkg.content[key]) {
+    pkg.content[key] = { version }
+  } else {
+    pkg.content[key].version = version
+  }
+  await pkg.save()
+}
+
+module.exports = {
+  run,
+  when: ({ config: c }) => c.needsUpdate && !c.isDogFood,
+  name: 'apply-version',
+}

--- a/lib/apply/index.js
+++ b/lib/apply/index.js
@@ -2,4 +2,5 @@ const run = require('../index.js')
 
 module.exports = (root, content) => run(root, content, [
   require('./apply-files.js'),
+  require('./apply-version.js'),
 ])

--- a/lib/config.js
+++ b/lib/config.js
@@ -56,6 +56,7 @@ const getConfig = async ({
   const isRoot = root === path
   const isLatest = version === LATEST_VERSION
   const isDogFood = pkg.name === NAME
+  const isForce = process.argv.includes('--force')
 
   // this is written to ci yml files so it needs to always use posix
   const pkgRelPath = makePosix(relative(root, path))
@@ -111,16 +112,17 @@ const getConfig = async ({
     pkgName: pkg.name,
     pkgNameFs: pkg.name.replace(/\//g, '-').replace(/@/g, ''),
     pkgRelPath: pkgRelPath,
-    // force changes if we are dogfooding this repo or with force argv
-    // XXX: setup proper cli arg parsing
-    isForce: isDogFood || process.argv.includes('--force'),
+    // booleans to control application of updates
+    isForce,
+    isDogFood,
     isLatest,
-    needsUpdate: !isLatest,
+    // needs update if we are dogfooding this repo, with force argv, or its
+    // behind the current version
+    needsUpdate: isForce || isDogFood || !isLatest,
     // templateoss specific values
     __NAME__: NAME,
     __CONFIG_KEY__: CONFIG_KEY,
     __VERSION__: LATEST_VERSION,
-    __DOGFOOD__: isDogFood,
   }
 
   // merge the rest of base and pkg content to make the

--- a/lib/content/eslintrc.js
+++ b/lib/content/eslintrc.js
@@ -5,6 +5,7 @@ const localConfigs = readdir(__dirname)
   .map((file) => `./${file}`)
 
 module.exports = {
+  root: true,
   extends: [
     '@npmcli',
     ...localConfigs,

--- a/lib/content/index.js
+++ b/lib/content/index.js
@@ -53,6 +53,7 @@ const workspaceModule = {
   rm: [
     '.npmrc',
     '.eslintrc.!(js|local.*)',
+    'SECURITY.md',
   ],
 }
 

--- a/lib/content/pkg.json
+++ b/lib/content/pkg.json
@@ -20,7 +20,7 @@
     "node": {{{json engines}}}
   },
   {{{json __CONFIG_KEY__}}}: {
-    "version": {{#if __DOGFOOD__}}{{{del}}}{{else}}{{{json __VERSION__}}}{{/if}}
+    "version": {{#if isDogFood}}{{{del}}}{{else}}{{{json __VERSION__}}}{{/if}}
   },
   "templateVersion": {{{del}}},
   "standard": {{{del}}}

--- a/tap-snapshots/test/apply/full-content.js.test.cjs
+++ b/tap-snapshots/test/apply/full-content.js.test.cjs
@@ -30,6 +30,7 @@ const localConfigs = readdir(__dirname)
   .map((file) => \`./\${file}\`)
 
 module.exports = {
+  root: true,
   extends: [
     '@npmcli',
     ...localConfigs,
@@ -503,6 +504,7 @@ const localConfigs = readdir(__dirname)
   .map((file) => \`./\${file}\`)
 
 module.exports = {
+  root: true,
   extends: [
     '@npmcli',
     ...localConfigs,
@@ -1222,6 +1224,7 @@ const localConfigs = readdir(__dirname)
   .map((file) => \`./\${file}\`)
 
 module.exports = {
+  root: true,
   extends: [
     '@npmcli',
     ...localConfigs,
@@ -1297,6 +1300,7 @@ const localConfigs = readdir(__dirname)
   .map((file) => \`./\${file}\`)
 
 module.exports = {
+  root: true,
   extends: [
     '@npmcli',
     ...localConfigs,

--- a/tap-snapshots/test/check/diffs.js.test.cjs
+++ b/tap-snapshots/test/check/diffs.js.test.cjs
@@ -71,7 +71,10 @@ source
 package.json
 ========================================
 {
-  "name": "testpkg"
+  "name": "testpkg",
+  "templateOSS": {
+    "version": "{{VERSION}}"
+  }
 }
 `
 
@@ -114,7 +117,10 @@ content/source.json
 package.json
 ========================================
 {
-  "name": "testpkg"
+  "name": "testpkg",
+  "templateOSS": {
+    "version": "{{VERSION}}"
+  }
 }
 
 target.json
@@ -163,7 +169,10 @@ content/source.json
 package.json
 ========================================
 {
-  "name": "testpkg"
+  "name": "testpkg",
+  "templateOSS": {
+    "version": "{{VERSION}}"
+  }
 }
 
 target.json
@@ -204,7 +213,10 @@ content/source.json
 package.json
 ========================================
 {
-  "name": "testpkg"
+  "name": "testpkg",
+  "templateOSS": {
+    "version": "{{VERSION}}"
+  }
 }
 
 target.json
@@ -276,7 +288,10 @@ source
 package.json
 ========================================
 {
-  "name": "testpkg"
+  "name": "testpkg",
+  "templateOSS": {
+    "version": "{{VERSION}}"
+  }
 }
 
 target.txt

--- a/test/apply/full-content.js
+++ b/test/apply/full-content.js
@@ -37,7 +37,12 @@ t.test('workspaces + everything', async (t) => {
 t.test('with empty content', async (t) => {
   const s = await setup(t, { content: {} })
   await s.apply()
-  t.strictSame(await s.readdirSource(), {
-    'package.json': JSON.stringify({ name: 'testpkg' }, null, 2),
+  const source = await s.readdirSource()
+  t.strictSame(Object.keys(source), ['package.json'])
+  t.strictSame(JSON.parse(source['package.json']), {
+    name: 'testpkg',
+    templateOSS: {
+      version: setup.pkgVersion,
+    },
   })
 })

--- a/test/setup.js
+++ b/test/setup.js
@@ -176,6 +176,7 @@ const formatSnapshots = {
 module.exports = setup
 module.exports.git = setupGit
 module.exports.content = CONTENT
+module.exports.pkgVersion = VERSION
 module.exports.clean = cleanSnapshot
 module.exports.format = formatSnapshots
 module.exports.okPackage = okPackage


### PR DESCRIPTION
- fix: properly apply file changes and version update
this allows individual workspaces to opt out of specific checks, and for the version to be properly updated in package.json even if the rest of the package.json update is not requested

- fix: rm security.md files from workspaces
this file is root only, so it makes sense to delete it from workspaces it if exists

- fix: add root: true to eslint configs
we are using eslint in each workspace, so we always want the `.eslintrc` file to use `root: true` so eslint doesn't traverse into the root and apply those rules
 