### PR TITLE
fix: update comment link to github permissions

### DIFF
--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -4,7 +4,7 @@ name: Post Dependabot Actions
 
 on: pull_request
 
-# https://docs.github.com/en/rest/overview/permissions-required-for-github-apps
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
 permissions:
   actions: write
   contents: write

--- a/lib/content/post-dependabot.yml
+++ b/lib/content/post-dependabot.yml
@@ -3,7 +3,7 @@ name: Post Dependabot Actions
 on:
   pull_request
 
-# https://docs.github.com/en/rest/overview/permissions-required-for-github-apps
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
 permissions:
   actions: write
   contents: write

--- a/tap-snapshots/test/apply/full-content.js.test.cjs
+++ b/tap-snapshots/test/apply/full-content.js.test.cjs
@@ -300,7 +300,7 @@ name: Post Dependabot Actions
 
 on: pull_request
 
-# https://docs.github.com/en/rest/overview/permissions-required-for-github-apps
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
 permissions:
   actions: write
   contents: write
@@ -964,7 +964,7 @@ name: Post Dependabot Actions
 
 on: pull_request
 
-# https://docs.github.com/en/rest/overview/permissions-required-for-github-apps
+# https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions
 permissions:
   actions: write
   contents: write


### PR DESCRIPTION
We are still trying to find out what `workflows` permissions is, exactly.  This at least will link to the right place.