### PR TITLE
fix: use ops+robot as git user for all ci

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -15,8 +15,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup git user
         run: |
-          git config --global user.email "ops+npm-cli@npmjs.com"
-          git config --global user.name "npm cli ops bot"
+          git config --global user.email "npm team"
+          git config --global user.name "ops+robot@npmjs.com"
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup git user
         run: |
-          git config --global user.email "ops+npm-cli@npmjs.com"
-          git config --global user.name "npm cli ops bot"
+          git config --global user.email "npm team"
+          git config --global user.name "ops+robot@npmjs.com"
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
@@ -59,8 +59,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup git user
         run: |
-          git config --global user.email "ops+npm-cli@npmjs.com"
-          git config --global user.name "npm cli ops bot"
+          git config --global user.email "npm team"
+          git config --global user.name "ops+robot@npmjs.com"
       - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -34,8 +34,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup git user
         run: |
-          git config --global user.email "ops+npm-cli@npmjs.com"
-          git config --global user.name "npm cli ops bot"
+          git config --global user.email "npm team"
+          git config --global user.name "ops+robot@npmjs.com"
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1
         with:

--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -16,8 +16,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup git user
         run: |
-          git config --global user.email "ops+npm-cli@npmjs.com"
-          git config --global user.name "npm cli ops bot"
+          git config --global user.email "npm team"
+          git config --global user.name "ops+robot@npmjs.com"
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -20,8 +20,8 @@ jobs:
           fetch-depth: 0
       - name: Setup git user
         run: |
-          git config --global user.email "ops+npm-cli@npmjs.com"
-          git config --global user.name "npm cli ops bot"
+          git config --global user.email "npm team"
+          git config --global user.name "ops+robot@npmjs.com"
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x

--- a/lib/content/setup-git.yml
+++ b/lib/content/setup-git.yml
@@ -7,5 +7,5 @@
 {{/if}}
 - name: Setup git user
   run: |
-    git config --global user.email "ops+npm-cli@npmjs.com"
-    git config --global user.name "npm cli ops bot"
+    git config --global user.email "npm team"
+    git config --global user.name "ops+robot@npmjs.com"

--- a/tap-snapshots/test/apply/full-content.js.test.cjs
+++ b/tap-snapshots/test/apply/full-content.js.test.cjs
@@ -145,8 +145,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup git user
         run: |
-          git config --global user.email "ops+npm-cli@npmjs.com"
-          git config --global user.name "npm cli ops bot"
+          git config --global user.email "npm team"
+          git config --global user.name "ops+robot@npmjs.com"
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
@@ -182,8 +182,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup git user
         run: |
-          git config --global user.email "ops+npm-cli@npmjs.com"
-          git config --global user.name "npm cli ops bot"
+          git config --global user.email "npm team"
+          git config --global user.name "ops+robot@npmjs.com"
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
@@ -219,8 +219,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup git user
         run: |
-          git config --global user.email "ops+npm-cli@npmjs.com"
-          git config --global user.name "npm cli ops bot"
+          git config --global user.email "npm team"
+          git config --global user.name "ops+robot@npmjs.com"
       - uses: actions/setup-node@v3
         with:
           node-version: \${{ matrix.node-version }}
@@ -283,8 +283,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup git user
         run: |
-          git config --global user.email "ops+npm-cli@npmjs.com"
-          git config --global user.name "npm cli ops bot"
+          git config --global user.email "npm team"
+          git config --global user.name "ops+robot@npmjs.com"
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1
         with:
@@ -312,8 +312,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup git user
         run: |
-          git config --global user.email "ops+npm-cli@npmjs.com"
-          git config --global user.name "npm cli ops bot"
+          git config --global user.email "npm team"
+          git config --global user.name "ops+robot@npmjs.com"
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
@@ -362,8 +362,8 @@ jobs:
           fetch-depth: 0
       - name: Setup git user
         run: |
-          git config --global user.email "ops+npm-cli@npmjs.com"
-          git config --global user.name "npm cli ops bot"
+          git config --global user.email "npm team"
+          git config --global user.name "ops+robot@npmjs.com"
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
@@ -623,8 +623,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup git user
         run: |
-          git config --global user.email "ops+npm-cli@npmjs.com"
-          git config --global user.name "npm cli ops bot"
+          git config --global user.email "npm team"
+          git config --global user.name "ops+robot@npmjs.com"
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
@@ -664,8 +664,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup git user
         run: |
-          git config --global user.email "ops+npm-cli@npmjs.com"
-          git config --global user.name "npm cli ops bot"
+          git config --global user.email "npm team"
+          git config --global user.name "ops+robot@npmjs.com"
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
@@ -701,8 +701,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup git user
         run: |
-          git config --global user.email "ops+npm-cli@npmjs.com"
-          git config --global user.name "npm cli ops bot"
+          git config --global user.email "npm team"
+          git config --global user.name "ops+robot@npmjs.com"
       - uses: actions/setup-node@v3
         with:
           node-version: \${{ matrix.node-version }}
@@ -757,8 +757,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup git user
         run: |
-          git config --global user.email "ops+npm-cli@npmjs.com"
-          git config --global user.name "npm cli ops bot"
+          git config --global user.email "npm team"
+          git config --global user.name "ops+robot@npmjs.com"
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
@@ -794,8 +794,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup git user
         run: |
-          git config --global user.email "ops+npm-cli@npmjs.com"
-          git config --global user.name "npm cli ops bot"
+          git config --global user.email "npm team"
+          git config --global user.name "ops+robot@npmjs.com"
       - uses: actions/setup-node@v3
         with:
           node-version: \${{ matrix.node-version }}
@@ -846,8 +846,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup git user
         run: |
-          git config --global user.email "ops+npm-cli@npmjs.com"
-          git config --global user.name "npm cli ops bot"
+          git config --global user.email "npm team"
+          git config --global user.name "ops+robot@npmjs.com"
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
@@ -883,8 +883,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup git user
         run: |
-          git config --global user.email "ops+npm-cli@npmjs.com"
-          git config --global user.name "npm cli ops bot"
+          git config --global user.email "npm team"
+          git config --global user.name "ops+robot@npmjs.com"
       - uses: actions/setup-node@v3
         with:
           node-version: \${{ matrix.node-version }}
@@ -947,8 +947,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup git user
         run: |
-          git config --global user.email "ops+npm-cli@npmjs.com"
-          git config --global user.name "npm cli ops bot"
+          git config --global user.email "npm team"
+          git config --global user.name "ops+robot@npmjs.com"
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1
         with:
@@ -976,8 +976,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup git user
         run: |
-          git config --global user.email "ops+npm-cli@npmjs.com"
-          git config --global user.name "npm cli ops bot"
+          git config --global user.email "npm team"
+          git config --global user.name "ops+robot@npmjs.com"
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
@@ -1026,8 +1026,8 @@ jobs:
           fetch-depth: 0
       - name: Setup git user
         run: |
-          git config --global user.email "ops+npm-cli@npmjs.com"
-          git config --global user.name "npm cli ops bot"
+          git config --global user.email "npm team"
+          git config --global user.name "ops+robot@npmjs.com"
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
@@ -1085,8 +1085,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup git user
         run: |
-          git config --global user.email "ops+npm-cli@npmjs.com"
-          git config --global user.name "npm cli ops bot"
+          git config --global user.email "npm team"
+          git config --global user.name "ops+robot@npmjs.com"
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x
@@ -1148,8 +1148,8 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup git user
         run: |
-          git config --global user.email "ops+npm-cli@npmjs.com"
-          git config --global user.name "npm cli ops bot"
+          git config --global user.email "npm team"
+          git config --global user.name "ops+robot@npmjs.com"
       - uses: actions/setup-node@v3
         with:
           node-version: 16.x

--- a/tap-snapshots/test/check/diffs.js.test.cjs
+++ b/tap-snapshots/test/check/diffs.js.test.cjs
@@ -311,7 +311,7 @@ The repo file ci.yml needs to be updated:
   .github/workflows/ci.yml
   ========================================
   @@ -63,4 +63,24 @@
-             git config --global user.name "npm cli ops bot"
+             git config --global user.name "ops+robot@npmjs.com"
          - uses: actions/setup-node@v3
            with:
              node-version: \${{ matrix.node-version }}
@@ -365,8 +365,8 @@ The repo file audit.yml needs to be updated:
         - uses: actions/checkout@v3
         - name: Setup git user
           run: |
-            git config --global user.email "ops+npm-cli@npmjs.com"
-            git config --global user.name "npm cli ops bot"
+            git config --global user.email "npm team"
+            git config --global user.name "ops+robot@npmjs.com"
         - uses: actions/setup-node@v3
           with:
             node-version: 16.x


### PR DESCRIPTION
I'm not sure if we want to do this, or if there was a reason to keep these bot users separate.

This would change the git user of all our CI commits to @npm-robot. This is the user we use to create PRs to `nodejs/node` (https://github.com/nodejs/node/pull/42550) and add benchmark comments (https://github.com/npm/cli/pull/4716#issuecomment-1093774243).