### PR TITLE
fix: compare to \n instead of os.EOL

### DIFF
--- a/lib/check/check-changelog.js
+++ b/lib/check/check-changelog.js
@@ -1,5 +1,4 @@
 const fs = require('@npmcli/fs')
-const { EOL } = require('os')
 const { join, relative } = require('path')
 
 const run = async ({ root, path }) => {
@@ -10,7 +9,7 @@ const run = async ({ root, path }) => {
 
   if (await fs.exists(changelog)) {
     const content = await fs.readFile(changelog, { encoding: 'utf8' })
-    const mustStart = `# Changelog${EOL}${EOL}#`
+    const mustStart = `# Changelog\n\n#`
     if (!content.startsWith(mustStart)) {
       return {
         title: `The ${relative(root, changelog)} is incorrect:`,

--- a/lib/util/get-git-url.js
+++ b/lib/util/get-git-url.js
@@ -18,7 +18,9 @@ const getRepo = async (path) => {
     const url = new URL(`https://${domain}`)
     url.pathname = `/${user}/${project}.git`
     return url.toString()
-  } catch {}
+  } catch {
+    // errors are ignored
+  }
 }
 
 module.exports = getRepo


### PR DESCRIPTION
os.EOL is \r\n in win32, which means this check is pretty much guaranteed to fail in windows
