### PR TITLE
feat: make cron workflows run early PT

### DIFF
--- a/lib/content/audit.yml
+++ b/lib/content/audit.yml
@@ -3,8 +3,8 @@ name: Audit
 on:
   workflow_dispatch:
   schedule:
-    # "At 01:00 on Monday" https://crontab.guru/#0_1_*_*_1
-    - cron: "0 1 * * 1"
+    # "At 08:00 UTC (01:00 PT) on Monday" https://crontab.guru/#0_8_*_*_1
+    - cron: "0 8 * * 1"
 
 jobs:
   audit:

--- a/lib/content/ci.yml
+++ b/lib/content/ci.yml
@@ -19,8 +19,8 @@ on:
       - {{pkgRelPath}}/**
     {{/if}}
   schedule:
-    # "At 02:00 on Monday" https://crontab.guru/#0_2_*_*_1
-    - cron: "0 2 * * 1"
+    # "At 09:00 UTC (02:00 PT) on Monday" https://crontab.guru/#0_9_*_*_1
+    - cron: "0 9 * * 1"
 
 jobs:
   lint:

--- a/lib/content/codeql-analysis.yml
+++ b/lib/content/codeql-analysis.yml
@@ -13,8 +13,8 @@ on:
       - {{.}}
       {{/each}}
   schedule:
-    # "At 03:00 on Monday" https://crontab.guru/#0_3_*_*_1
-    - cron: "0 3 * * 1"
+    # "At 10:00 UTC (03:00 PT) on Monday" https://crontab.guru/#0_10_*_*_1
+    - cron: "0 10 * * 1"
 
 jobs:
   analyze:


### PR DESCRIPTION
This will help these checks run a few hours before Statusboard and be up to date for morning in Pacific Time.