### PR TITLE
fix: pin yaml to 2.0.0-11

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "npm-package-arg": "^9.0.1",
     "proc-log": "^2.0.0",
     "semver": "^7.3.5",
-    "yaml": "^2.0.0-11"
+    "yaml": "2.0.0-11"
   },
   "files": [
     "bin/",


### PR DESCRIPTION
yaml@2.0.0 or greater depends on node@14 while 2.0.0-11 still works in node 12. for now, i pinned our version here so we don't get CI failures in node 12. we'll probably be able to revert this once we raise our low bar to node 14
