### PR TITLE
fix: remove more usage of os.EOL

### DIFF
--- a/lib/check/check-changelog.js
+++ b/lib/check/check-changelog.js
@@ -9,13 +9,13 @@ const run = async ({ root, path }) => {
 
   if (await fs.exists(changelog)) {
     const content = await fs.readFile(changelog, { encoding: 'utf8' })
-    const mustStart = `# Changelog\n\n#`
-    if (!content.startsWith(mustStart)) {
+    const mustStart = /^#\s+Changelog\r?\n\r?\n#/
+    if (!mustStart.test(content)) {
       return {
         title: `The ${relative(root, changelog)} is incorrect:`,
         body: [
           'The changelog should start with',
-          `"${mustStart}"`,
+          `"# Changelog\n\n#"`,
         ],
         solution: 'reformat the changelog to have the correct heading',
       }

--- a/lib/check/check-gitignore.js
+++ b/lib/check/check-gitignore.js
@@ -1,5 +1,4 @@
 const log = require('proc-log')
-const { EOL } = require('os')
 const { resolve, relative, basename } = require('path')
 const fs = require('@npmcli/fs')
 const git = require('@npmcli/git')
@@ -48,7 +47,7 @@ const run = async ({ root, path, config }) => {
 
   const ignores = (await fs.readFile(ignoreFile))
     .toString()
-    .split(EOL)
+    .split(/\r?\n/)
     .filter((l) => l && !l.trim().startsWith('#'))
 
   const relIgnore = relativeToRoot(ignoreFile)

--- a/lib/util/parser.js
+++ b/lib/util/parser.js
@@ -1,5 +1,4 @@
 const fs = require('@npmcli/fs')
-const { EOL } = require('os')
 const { basename, extname, dirname } = require('path')
 const yaml = require('yaml')
 const NpmPackageJson = require('@npmcli/package-json')
@@ -56,7 +55,7 @@ class Base {
 
   prepare (s) {
     const header = this.header()
-    return header ? header + EOL + EOL + s : s
+    return header ? `${header}\n\n${s}` : s
   }
 
   prepareTarget (s) {


### PR DESCRIPTION
we should only ever write files with a `\n` line ending, even in windows. let's stop doing the platform specific thing and be general so we can stop getting hard to trace issues in windows
