### PR TITLE
fix: dont run workflows outside of npm org

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   audit:
+    if: github.repository_owner == 'npm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ on:
 
 jobs:
   lint:
+    if: github.repository_owner == 'npm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -34,6 +35,7 @@ jobs:
       - run: npm run lint
 
   test:
+    if: github.repository_owner == 'npm'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -10,8 +10,8 @@ permissions:
 
 jobs:
   template-oss-apply:
+    if: github.repository_owner == 'npm' && github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   check:
     name: Check PR Title or Commits
+    if: github.repository_owner == 'npm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,6 +17,7 @@ jobs:
     outputs:
       pr: ${{ steps.release.outputs.pr }}
       release: ${{ steps.release.outputs.release }}
+    if: github.repository_owner == 'npm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -79,7 +80,7 @@ jobs:
 
   post-release:
     needs: release-please
-    if: needs.release-please.outputs.release
+    if: github.repository_owner == 'npm' && needs.release-please.outputs.release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   lint-all:
+    if: github.repository_owner == 'npm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -30,6 +31,7 @@ jobs:
       - run: npm run lint -ws -iwr --if-present
 
   test-all:
+    if: github.repository_owner == 'npm'
     strategy:
       fail-fast: false
       matrix:

--- a/lib/content/_setup-job-matrix.yml
+++ b/lib/content/_setup-job-matrix.yml
@@ -1,3 +1,4 @@
+if: github.repository_owner == 'npm'
 strategy:
   fail-fast: false
   matrix:

--- a/lib/content/_setup-job.yml
+++ b/lib/content/_setup-job.yml
@@ -1,3 +1,4 @@
+if: github.repository_owner == 'npm' {{~#if jobIf}} && {{{jobIf}}}{{/if}}
 runs-on: ubuntu-latest
 steps:
   {{> setupGit}}

--- a/lib/content/audit.yml
+++ b/lib/content/audit.yml
@@ -8,9 +8,5 @@ on:
 
 jobs:
   audit:
-    runs-on: ubuntu-latest
-    steps:
-      {{> setupGit}}
-      {{> setupNode}}
-      {{> setupDeps flags="--package-lock"}}
+    {{> setupJob flags="--package-lock"}}
       - run: {{rootNpmPath}} audit

--- a/lib/content/post-dependabot.yml
+++ b/lib/content/post-dependabot.yml
@@ -9,12 +9,7 @@ permissions:
 
 jobs:
   template-oss-apply:
-    runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
-    steps:
-      {{> setupGit checkout=(obj ref="${{ github.event.pull_request.head_ref }}")}}
-      {{> setupNode}}
-      {{> setupDeps}}
+    {{> setupJob jobIf="github.actor == 'dependabot[bot]'" checkout=(obj ref="${{ github.event.pull_request.head_ref }}")}}
       - name: Dependabot metadata
         id: metadata
         uses: dependabot/fetch-metadata@v1.1.1

--- a/lib/content/pull-request.yml
+++ b/lib/content/pull-request.yml
@@ -11,11 +11,7 @@ on:
 jobs:
   check:
     name: Check PR Title or Commits
-    runs-on: ubuntu-latest
-    steps:
-      {{> setupGit checkout=(obj fetch-depth=0)}}
-      {{> setupNode}}
-      {{> setupDeps}}
+    {{> setupJob checkout=(obj fetch-depth=0)}}
       - name: Check commits or PR title
         env:
           PR_TITLE: $\{{ github.event.pull_request.title }}

--- a/lib/content/release-please.yml
+++ b/lib/content/release-please.yml
@@ -56,8 +56,7 @@ jobs:
 
   post-release:
     needs: release-please
-    if: needs.release-please.outputs.release
-    {{> setupJob }}
+    {{> setupJob jobIf="needs.release-please.outputs.release" }}
       - name: Post release actions
         env:
           GITHUB_TOKEN: $\{{ secrets.GITHUB_TOKEN }}

--- a/lib/content/release.yml
+++ b/lib/content/release.yml
@@ -10,11 +10,7 @@ on:
 
 jobs:
   lint-all:
-    runs-on: ubuntu-latest
-    steps:
-      {{> setupGit checkout=(obj ref="${{ inputs.ref }}")}}
-      {{> setupNode}}
-      {{> setupDeps}}
+    {{> setupJob checkout=(obj ref="${{ inputs.ref }}")}}
       - run: {{rootNpmPath}} run lint -ws -iwr --if-present
 
   test-all:

--- a/tap-snapshots/test/apply/source-snapshots.js.test.cjs
+++ b/tap-snapshots/test/apply/source-snapshots.js.test.cjs
@@ -177,6 +177,7 @@ on:
 
 jobs:
   audit:
+    if: github.repository_owner == 'npm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -214,6 +215,7 @@ on:
 
 jobs:
   lint:
+    if: github.repository_owner == 'npm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -231,6 +233,7 @@ jobs:
       - run: npm run lint
 
   test:
+    if: github.repository_owner == 'npm'
     strategy:
       fail-fast: false
       matrix:
@@ -345,8 +348,8 @@ permissions:
 
 jobs:
   template-oss-apply:
+    if: github.repository_owner == 'npm' && github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -394,6 +397,7 @@ on:
 jobs:
   check:
     name: Check PR Title or Commits
+    if: github.repository_owner == 'npm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -438,6 +442,7 @@ jobs:
     outputs:
       pr: \${{ steps.release.outputs.pr }}
       release: \${{ steps.release.outputs.release }}
+    if: github.repository_owner == 'npm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -500,7 +505,7 @@ jobs:
 
   post-release:
     needs: release-please
-    if: needs.release-please.outputs.release
+    if: github.repository_owner == 'npm' && needs.release-please.outputs.release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -536,6 +541,7 @@ on:
 
 jobs:
   lint-all:
+    if: github.repository_owner == 'npm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -555,6 +561,7 @@ jobs:
       - run: npm run lint -ws -iwr --if-present
 
   test-all:
+    if: github.repository_owner == 'npm'
     strategy:
       fail-fast: false
       matrix:
@@ -963,6 +970,7 @@ on:
 
 jobs:
   audit:
+    if: github.repository_owner == 'npm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -1004,6 +1012,7 @@ on:
 
 jobs:
   lint:
+    if: github.repository_owner == 'npm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -1021,6 +1030,7 @@ jobs:
       - run: npm run lint -w a
 
   test:
+    if: github.repository_owner == 'npm'
     strategy:
       fail-fast: false
       matrix:
@@ -1099,6 +1109,7 @@ on:
 
 jobs:
   lint:
+    if: github.repository_owner == 'npm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -1116,6 +1127,7 @@ jobs:
       - run: npm run lint -w b
 
   test:
+    if: github.repository_owner == 'npm'
     strategy:
       fail-fast: false
       matrix:
@@ -1196,6 +1208,7 @@ on:
 
 jobs:
   lint:
+    if: github.repository_owner == 'npm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -1213,6 +1226,7 @@ jobs:
       - run: npm run lint
 
   test:
+    if: github.repository_owner == 'npm'
     strategy:
       fail-fast: false
       matrix:
@@ -1327,8 +1341,8 @@ permissions:
 
 jobs:
   template-oss-apply:
+    if: github.repository_owner == 'npm' && github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
     steps:
       - uses: actions/checkout@v3
         with:
@@ -1376,6 +1390,7 @@ on:
 jobs:
   check:
     name: Check PR Title or Commits
+    if: github.repository_owner == 'npm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -1420,6 +1435,7 @@ jobs:
     outputs:
       pr: \${{ steps.release.outputs.pr }}
       release: \${{ steps.release.outputs.release }}
+    if: github.repository_owner == 'npm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -1482,7 +1498,7 @@ jobs:
 
   post-release:
     needs: release-please
-    if: needs.release-please.outputs.release
+    if: github.repository_owner == 'npm' && needs.release-please.outputs.release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -1518,6 +1534,7 @@ on:
 
 jobs:
   lint-all:
+    if: github.repository_owner == 'npm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -1537,6 +1554,7 @@ jobs:
       - run: npm run lint -ws -iwr --if-present
 
   test-all:
+    if: github.repository_owner == 'npm'
     strategy:
       fail-fast: false
       matrix:
@@ -1964,6 +1982,7 @@ on:
 
 jobs:
   lint:
+    if: github.repository_owner == 'npm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -1981,6 +2000,7 @@ jobs:
       - run: npm run lint -w a
 
   test:
+    if: github.repository_owner == 'npm'
     strategy:
       fail-fast: false
       matrix:
@@ -2059,6 +2079,7 @@ on:
 
 jobs:
   lint:
+    if: github.repository_owner == 'npm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -2076,6 +2097,7 @@ jobs:
       - run: npm run lint -w b
 
   test:
+    if: github.repository_owner == 'npm'
     strategy:
       fail-fast: false
       matrix:
@@ -2150,6 +2172,7 @@ jobs:
     outputs:
       pr: \${{ steps.release.outputs.pr }}
       release: \${{ steps.release.outputs.release }}
+    if: github.repository_owner == 'npm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -2212,7 +2235,7 @@ jobs:
 
   post-release:
     needs: release-please
-    if: needs.release-please.outputs.release
+    if: github.repository_owner == 'npm' && needs.release-please.outputs.release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -2248,6 +2271,7 @@ on:
 
 jobs:
   lint-all:
+    if: github.repository_owner == 'npm'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -2267,6 +2291,7 @@ jobs:
       - run: npm run lint -ws -iwr --if-present
 
   test-all:
+    if: github.repository_owner == 'npm'
     strategy:
       fail-fast: false
       matrix:

--- a/tap-snapshots/test/check/diff-snapshots.js.test.cjs
+++ b/tap-snapshots/test/check/diff-snapshots.js.test.cjs
@@ -112,6 +112,7 @@ The repo file audit.yml needs to be updated:
   
   jobs:
     audit:
+      if: github.repository_owner == 'npm'
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v3
@@ -137,7 +138,7 @@ The repo file ci.yml needs to be updated:
 
   .github/workflows/ci.yml
   ========================================
-  @@ -65,4 +65,24 @@
+  @@ -67,4 +67,24 @@
            with:
              node-version: \${{ matrix.node-version }}
          - name: Update to workable npm (windows)


### PR DESCRIPTION
This adds a `if: github.repository_owner == 'npm'` to each workflow so
they don't run outside of the npm organization by default.

Closes #182
