### PR TITLE
fix: wrap pr title and base_ref in quotes

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -41,8 +41,8 @@ jobs:
         id: commit
         continue-on-error: true
         run: |
-          npx --offline commitlint -V --from origin/${{ github.base_ref }} --to ${{ github.event.pull_request.head.sha }}
+          npx --offline commitlint -V --from 'origin/${{ github.base_ref }}' --to ${{ github.event.pull_request.head.sha }}
       - name: Run Commitlint on PR Title
         if: steps.commit.outcome == 'failure'
         run: |
-          echo ${{ github.event.pull_request.title }} | npx --offline commitlint -V
+          echo '${{ github.event.pull_request.title }}' | npx --offline commitlint -V

--- a/lib/content/pull-request.yml
+++ b/lib/content/pull-request.yml
@@ -15,8 +15,8 @@ jobs:
         id: commit
         continue-on-error: true
         run: |
-          {{ rootNpxPath }} --offline commitlint -V --from origin/$\{{ github.base_ref }} --to $\{{ github.event.pull_request.head.sha }}
+          {{ rootNpxPath }} --offline commitlint -V --from 'origin/$\{{ github.base_ref }}' --to $\{{ github.event.pull_request.head.sha }}
       - name: Run Commitlint on PR Title
         if: steps.commit.outcome == 'failure'
         run: |
-          echo $\{{ github.event.pull_request.title }} | {{ rootNpxPath }} --offline commitlint -V
+          echo '$\{{ github.event.pull_request.title }}' | {{ rootNpxPath }} --offline commitlint -V

--- a/tap-snapshots/test/apply/source-snapshots.js.test.cjs
+++ b/tap-snapshots/test/apply/source-snapshots.js.test.cjs
@@ -744,11 +744,11 @@ jobs:
         id: commit
         continue-on-error: true
         run: |
-          npx --offline commitlint -V --from origin/\${{ github.base_ref }} --to \${{ github.event.pull_request.head.sha }}
+          npx --offline commitlint -V --from 'origin/\${{ github.base_ref }}' --to \${{ github.event.pull_request.head.sha }}
       - name: Run Commitlint on PR Title
         if: steps.commit.outcome == 'failure'
         run: |
-          echo \${{ github.event.pull_request.title }} | npx --offline commitlint -V
+          echo '\${{ github.event.pull_request.title }}' | npx --offline commitlint -V
 
 .github/workflows/release.yml
 ========================================
@@ -2214,11 +2214,11 @@ jobs:
         id: commit
         continue-on-error: true
         run: |
-          npx --offline commitlint -V --from origin/\${{ github.base_ref }} --to \${{ github.event.pull_request.head.sha }}
+          npx --offline commitlint -V --from 'origin/\${{ github.base_ref }}' --to \${{ github.event.pull_request.head.sha }}
       - name: Run Commitlint on PR Title
         if: steps.commit.outcome == 'failure'
         run: |
-          echo \${{ github.event.pull_request.title }} | npx --offline commitlint -V
+          echo '\${{ github.event.pull_request.title }}' | npx --offline commitlint -V
 
 .github/workflows/release.yml
 ========================================
@@ -3527,11 +3527,11 @@ jobs:
         id: commit
         continue-on-error: true
         run: |
-          npx --offline commitlint -V --from origin/\${{ github.base_ref }} --to \${{ github.event.pull_request.head.sha }}
+          npx --offline commitlint -V --from 'origin/\${{ github.base_ref }}' --to \${{ github.event.pull_request.head.sha }}
       - name: Run Commitlint on PR Title
         if: steps.commit.outcome == 'failure'
         run: |
-          echo \${{ github.event.pull_request.title }} | npx --offline commitlint -V
+          echo '\${{ github.event.pull_request.title }}' | npx --offline commitlint -V
 
 .github/workflows/release.yml
 ========================================


### PR DESCRIPTION
the quotes are necessary here because a pr title (and a base_ref) could have characters in them that bash tries to evaluate, to prevent that i wrapped them in single quotes

