### PR TITLE
Update linting configuration

### DIFF
--- a/lib/content/pkg.json
+++ b/lib/content/pkg.json
@@ -2,7 +2,7 @@
   "author": "GitHub Inc.",
   "files": {{{ json distPaths }}},
   "scripts": {
-    "lint": "eslint \"**/*.js\"",
+    "lint": "eslint \"**/*.{js,jsx}\"",
     "postlint": "template-oss-check",
     "template-oss-apply": "template-oss-apply --force",
     "lintfix": "{{ localNpmPath }} run lint -- --fix",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "template-oss-release-manager": "bin/release-manager.js"
   },
   "scripts": {
-    "lint": "eslint \"**/*.js\"",
+    "lint": "eslint \"**/*.{js,jsx}\"",
     "lintfix": "npm run lint -- --fix",
     "posttest": "npm run lint",
     "snap": "tap",
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/npm/template-oss.git"
+    "url": "https://github.com/kendallgassner/template-oss.git"
   },
   "keywords": [
     "npm",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/kendallgassner/template-oss.git"
+    "url": "https://github.com/npm/template-oss.git",
   },
   "keywords": [
     "npm",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/npm/template-oss.git",
+    "url": "https://github.com/npm/template-oss.git"
   },
   "keywords": [
     "npm",

--- a/workspace/test-workspace/package.json
+++ b/workspace/test-workspace/package.json
@@ -20,7 +20,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/npm/template-oss.git",
+    "url": "https://github.com/kendallgassner/template-oss.git",
     "directory": "workspace/test-workspace"
   },
   "keywords": [],

--- a/workspace/test-workspace/package.json
+++ b/workspace/test-workspace/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "test": "tap",
-    "lint": "eslint \"**/*.js\"",
+    "lint": "eslint \"**/*.{js,jsx}\"",
     "postlint": "template-oss-check",
     "template-oss-apply": "template-oss-apply --force",
     "lintfix": "npm run lint -- --fix",

--- a/workspace/test-workspace/package.json
+++ b/workspace/test-workspace/package.json
@@ -20,7 +20,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/kendallgassner/template-oss.git",
+    "url": "https://github.com/npm/template-oss.git",
     "directory": "workspace/test-workspace"
   },
   "keywords": [],


### PR DESCRIPTION
### What
I would like to lint both .js files and .jsx files so that I can properly use [eslint-plugin-jsx-a11y](https://www.npmjs.com/package/eslint-plugin-jsx-a11y). Any chance we can update the template-oss to match this configuration show we can access jsx files in the npm/documentation?

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
