### PR TITLE
Add logging and dispatch to rerun release workflows on tagged releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -295,14 +295,17 @@ jobs:
             }
 
             const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number })
-            const releaseComments = comments.filter(c => c.user.login === 'github-actions[bot]' && c.body.includes('Release is at'))
+              .then(cs => cs.map(c => ({ id: c.id, login: c.user.login, body: c.body })))
+            console.log(`Found comments: ${JSON.stringify(comments, null, 2)}`)
+            const releaseComments = comments.filter(c => c.login === 'github-actions[bot]' && c.body.includes('Release is at'))
 
             for (const comment of releaseComments) {
+              console.log(`Release comment: ${JSON.stringify(comment, null, 2)}`)
               await github.rest.issues.deleteComment({ owner, repo, comment_id: comment.id })
             }
 
             const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${runId}`
-            await github.rest.issues.createComment({ 
+            await github.rest.issues.createComment({
               owner,
               repo,
               issue_number,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,10 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      release-pr:
+        description: a release PR number to rerun release jobs on
+        type: string
   push:
     branches:
       - main
@@ -53,7 +57,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          npx --offline template-oss-release-please ${{ github.ref_name }} ${{ github.event_name }}
+          npx --offline template-oss-release-please "${{ github.ref_name }}" "${{ inputs.release-pr }}"
       - name: Post Pull Request Comment
         if: steps.release.outputs.pr-number
         uses: actions/github-script@v6
@@ -76,7 +80,7 @@ jobs:
             body += `Release workflow run: ${workflow.html_url}\n\n#### Force CI to Update This Release\n\n`
             body += `This PR will be updated and CI will run for every non-\`chore:\` commit that is pushed to \`main\`. `
             body += `To force CI to update this PR, run this command:\n\n`
-            body += `\`\`\`\ngh workflow run release.yml -r ${REF_NAME} -R ${owner}/${repo}\n\`\`\``
+            body += `\`\`\`\ngh workflow run release.yml -r ${REF_NAME} -R ${owner}/${repo} -f release-pr=${issue_number}\n\`\`\``
 
             if (commentId) {
               await github.rest.issues.updateComment({ owner, repo, comment_id: commentId, body })
@@ -378,10 +382,14 @@ jobs:
         with:
           script: |
             const { PR_NUMBER: issue_number, RESULT } = process.env
-            const { repo: { owner, repo } } = context
+            const { runId, repo: { owner, repo } } = context
 
             const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number })
-            const updateComment = comments.find(c => c.user.login === 'github-actions[bot]' && c.body.startsWith('## Release Workflow\n\n'))
+            const updateComment = comments.find(c =>
+              c.user.login === 'github-actions[bot]' &&
+              c.body.startsWith('## Release Workflow\n\n') &&
+              c.body.includes(runId)
+            )
 
             if (updateComment) {
               console.log('Found comment to update:', JSON.stringify(updateComment, null, 2))

--- a/bin/release-please.js
+++ b/bin/release-please.js
@@ -4,7 +4,7 @@ const core = require('@actions/core')
 const main = require('../lib/release-please/index.js')
 
 const dryRun = !process.env.CI
-const [branch, eventName] = process.argv.slice(2)
+const [branch, forcePullRequest] = process.argv.slice(2)
 
 const debugPr = (val) => {
   if (dryRun) {
@@ -45,7 +45,7 @@ main({
   repo: process.env.GITHUB_REPOSITORY,
   dryRun,
   branch,
-  force: eventName === 'workflow_dispatch',
+  forcePullRequest: forcePullRequest ? +forcePullRequest : null,
 }).then(({ pr, release, releases }) => {
   if (pr) {
     debugPr(pr)

--- a/lib/content/release.yml
+++ b/lib/content/release.yml
@@ -143,14 +143,17 @@ jobs:
             }
 
             const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number })
-            const releaseComments = comments.filter(c => c.user.login === 'github-actions[bot]' && c.body.includes('Release is at'))
+              .then(cs => cs.map(c => ({ id: c.id, login: c.user.login, body: c.body })))
+            console.log(`Found comments: ${JSON.stringify(comments, null, 2)}`)
+            const releaseComments = comments.filter(c => c.login === 'github-actions[bot]' && c.body.includes('Release is at'))
 
             for (const comment of releaseComments) {
+              console.log(`Release comment: ${JSON.stringify(comment, null, 2)}`)
               await github.rest.issues.deleteComment({ owner, repo, comment_id: comment.id })
             }
 
             const runUrl = `https://github.com/${owner}/${repo}/actions/runs/${runId}`
-            await github.rest.issues.createComment({ 
+            await github.rest.issues.createComment({
               owner,
               repo,
               issue_number,

--- a/lib/content/release.yml
+++ b/lib/content/release.yml
@@ -2,6 +2,10 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      release-pr:
+        description: a release PR number to rerun release jobs on
+        type: string
   push:
     branches:
       {{#each branches}}
@@ -30,7 +34,7 @@ jobs:
         env:
           GITHUB_TOKEN: $\{{ secrets.GITHUB_TOKEN }}
         run: |
-          {{ rootNpxPath }} --offline template-oss-release-please $\{{ github.ref_name }} $\{{ github.event_name }}
+          {{ rootNpxPath }} --offline template-oss-release-please "$\{{ github.ref_name }}" "$\{{ inputs.release-pr }}"
       - name: Post Pull Request Comment
         if: steps.release.outputs.pr-number
         uses: actions/github-script@v6
@@ -53,7 +57,7 @@ jobs:
             body += `Release workflow run: ${workflow.html_url}\n\n#### Force CI to Update This Release\n\n`
             body += `This PR will be updated and CI will run for every non-\`chore:\` commit that is pushed to \`{{ defaultBranch }}\`. `
             body += `To force CI to update this PR, run this command:\n\n`
-            body += `\`\`\`\ngh workflow run release.yml -r ${REF_NAME} -R ${owner}/${repo}\n\`\`\``
+            body += `\`\`\`\ngh workflow run release.yml -r ${REF_NAME} -R ${owner}/${repo} -f release-pr=${issue_number}\n\`\`\``
 
             if (commentId) {
               await github.rest.issues.updateComment({ owner, repo, comment_id: commentId, body })
@@ -182,10 +186,14 @@ jobs:
         with:
           script: |
             const { PR_NUMBER: issue_number, RESULT } = process.env
-            const { repo: { owner, repo } } = context
+            const { runId, repo: { owner, repo } } = context
 
             const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number })
-            const updateComment = comments.find(c => c.user.login === 'github-actions[bot]' && c.body.startsWith('## Release Workflow\n\n'))
+            const updateComment = comments.find(c =>
+              c.user.login === 'github-actions[bot]' &&
+              c.body.startsWith('## Release Workflow\n\n') &&
+              c.body.includes(runId)
+            )
 
             if (updateComment) {
               console.log('Found comment to update:', JSON.stringify(updateComment, null, 2))

--- a/lib/release-please/index.js
+++ b/lib/release-please/index.js
@@ -4,10 +4,83 @@ const ChangelogNotes = require('./changelog.js')
 const Version = require('./version.js')
 const NodeWs = require('./node-workspace.js')
 
-RP.setLogger(new CheckpointLogger(true, true))
+const logger = new CheckpointLogger(true, true)
+RP.setLogger(logger)
 RP.registerChangelogNotes('default', (o) => new ChangelogNotes(o))
 RP.registerVersioningStrategy('default', (o) => new Version(o))
 RP.registerPlugin('node-workspace', (o) => new NodeWs(o.github, o.targetBranch, o.repositoryConfig))
+
+const omit = (obj, ...keys) => {
+  const res = {}
+  for (const [key, value] of Object.entries(obj)) {
+    if (!keys.includes(key)) {
+      res[key] = value
+    }
+  }
+  return res
+}
+
+const getReleaseArtifacts = async ({ dryRun, github, baseBranch }) => {
+  // This is mostly for testing and debugging. Use environs with the
+  // format `RELEASE_PLEASE_<manfiestOverrideConfigName>` (eg
+  // `RELEASE_PLEASE_lastReleaseSha=<SHA>`) to set one-off config items
+  // for the release please run without needing to commit and push the config.
+  const manifestOverrides = Object.entries(process.env)
+    .filter(([k, v]) => k.startsWith('RELEASE_PLEASE_') && v != null)
+    .map(([k, v]) => [k.replace('RELEASE_PLEASE_', ''), v])
+
+  const manifest = await RP.Manifest.fromManifest(
+    github,
+    baseBranch,
+    undefined,
+    undefined,
+    Object.fromEntries(manifestOverrides)
+  )
+
+  let pullRequests
+  let releases
+
+  if (dryRun) {
+    pullRequests = await manifest.buildPullRequests()
+    releases = await manifest.buildReleases()
+  } else {
+    pullRequests = await manifest.createPullRequests()
+    releases = await manifest.createReleases()
+  }
+
+  return {
+    pullRequests: pullRequests.filter(Boolean),
+    releases: releases.filter(Boolean),
+  }
+}
+
+const forcePullRequest = async ({ octokit, owner, repo, baseBranch }) => {
+  const { data: releasePrs } = await octokit.pulls.list({
+    owner,
+    repo,
+    head: `release-please--branches--${baseBranch}`,
+  })
+
+  if (releasePrs.length !== 1) {
+    throw new Error(`Found ${releasePrs.length} matching PRs, expected 1`)
+  }
+
+  const [releasePr] = releasePrs
+  const id = process.env.GITHUB_RUN_ID
+    ? `by https://github.com/${owner}/${repo}/actions/runs/${process.env.GITHUB_RUN_ID}`
+    : `manually starting at ${new Date().toJSON()}`
+
+  // XXX(hack): to get release please to recreate a pull request it needs
+  // to have a different body string so we append a message a message that CI
+  // is running. This will force release-please to rebase the PR but it
+  // wont update the body again, so we only append to it.
+  await octokit.pulls.update({
+    owner,
+    repo,
+    pull_number: releasePr.number,
+    body: `${releasePr.body.trim()}\n- This PR is being recreated ${id}`,
+  })
+}
 
 const main = async ({ repo: _fullRepo, token, dryRun, branch, force }) => {
   if (!token) {
@@ -19,103 +92,105 @@ const main = async ({ repo: _fullRepo, token, dryRun, branch, force }) => {
   }
 
   const fullRepo = _fullRepo.split('/')
-  const github = await RP.GitHub.create({ owner: fullRepo[0], repo: fullRepo[1], token })
+  const github = await RP.GitHub.create({
+    owner: fullRepo[0],
+    repo: fullRepo[1],
+    token,
+  })
   const {
     octokit,
     repository: { owner, repo, defaultBranch },
   } = github
 
-  // This is mostly for testing and debugging. Use environs with the
-  // format `RELEASE_PLEASE_<manfiestOverrideConfigName>` (eg
-  // `RELEASE_PLEASE_lastReleaseSha=<SHA>`) to set one-off config items
-  // for the release please run without needing to commit and push the config.
-  const manifestOverrides = Object.entries(process.env)
-    .filter(([k, v]) => k.startsWith('RELEASE_PLEASE_') && v != null)
-    .map(([k, v]) => [k.replace('RELEASE_PLEASE_', ''), v])
-
   const baseBranch = branch ?? defaultBranch
 
-  const manifest = await RP.Manifest.fromManifest(
-    github,
-    baseBranch,
-    undefined,
-    undefined,
-    Object.fromEntries(manifestOverrides)
-  )
-
   if (force) {
-    const { data: releasePrs } = await octokit.pulls.list({
-      owner,
-      repo,
-      head: `release-please--branches--${baseBranch}`,
-    })
-
-    if (releasePrs.length !== 1) {
-      throw new Error(`Found ${releasePrs.length} matching PRs, expected 1`)
-    }
-
-    const [releasePr] = releasePrs
-    const id = process.env.GITHUB_RUN_ID
-      ? `by https://github.com/${owner}/${repo}/actions/runs/${process.env.GITHUB_RUN_ID}`
-      : `manually starting at ${new Date().toJSON()}`
-
-    // XXX(hack): to get release please to recreate a pull request it needs
-    // to have a different body string so we append a message a message that CI
-    // is running. This will force release-please to rebase the PR but it
-    // wont update the body again, so we only append to it.
-    await octokit.pulls.update({
-      owner,
-      repo,
-      pull_number: releasePr.number,
-      body: `${releasePr.body.trim()}\n- This PR is being recreated ${id}`,
-    })
+    await forcePullRequest({ octokit, owner, repo, baseBranch })
   }
 
-  const pullRequests = await (dryRun ? manifest.buildPullRequests() : manifest.createPullRequests())
-  const allReleases = await (dryRun ? manifest.buildReleases() : manifest.createReleases())
+  const { pullRequests, releases } = await getReleaseArtifacts({ dryRun, github, baseBranch })
 
   // We only ever get a single pull request with our current release-please settings
-  const rootPr = pullRequests.filter(Boolean)?.[0]
+  // Update this if we start creating individual PRs per workspace release
+  const rootPr = pullRequests[0]
+  let rootRelease = releases[0]
+
+  logger.debug(`pull requests: ${pullRequests.length}`)
+  logger.debug(`releases: ${releases.length}`)
+
+  if (rootPr) {
+    logger.debug(`root pr: ${JSON.stringify(omit(rootPr, 'body'), null, 2)}`)
+  }
+
   if (rootPr?.number) {
     const commits = await octokit.paginate(octokit.rest.pulls.listCommits, {
       owner,
       repo,
       pull_number: rootPr.number,
     })
-    rootPr.sha = commits?.[commits.length - 1]?.sha
-  }
 
-  const releases = allReleases.filter(Boolean)
-  let rootRelease = releases[0]
-
-  for (const release of releases) {
-    const prefix = release.path === '.' ? '' : release.path
-
-    if (!prefix) {
-      rootRelease = release
+    const prSha = commits?.[commits.length - 1]?.sha
+    if (!prSha) {
+      throw new Error(`Could not find a latest sha for pull request: ${rootPr.number}`)
     }
 
-    const [releasePr, releasePkg] = await Promise.all([
-      octokit.rest.repos.listPullRequestsAssociatedWithCommit({
-        owner,
-        repo,
-        commit_sha: release.sha,
-      }).then(r => r.data[0]),
-      octokit.rest.repos.getContent({
-        owner,
-        repo,
-        ref: baseBranch,
-        path: `${prefix}/package.json`,
-      }).then(r => JSON.parse(Buffer.from(r.data.content, r.data.encoding))),
-    ])
+    rootPr.sha = prSha
+  }
 
-    release.prNumber = releasePr.number
-    release.pkgName = releasePkg.name
+  for (const release of releases) {
+    const { path, sha } = release
+    const prefix = path === '.' ? '' : path
+    const isRoot = !prefix
+    const packagePath = `${prefix}/package.json`
+
+    logger.debug(`release: ${JSON.stringify({
+      ...omit(release, 'notes'),
+      isRoot,
+      prefix,
+    }, null, 2)}`)
+
+    const releasePrNumber = await octokit.rest.repos.listPullRequestsAssociatedWithCommit({
+      owner,
+      repo,
+      commit_sha: sha,
+      per_page: 1,
+    }).then(r => r.data[0]?.number)
+
+    if (!releasePrNumber) {
+      throw new Error(`Could not find release PR number from commit: "${sha}"`)
+    }
+
+    logger.debug(`pr from ${sha}: ${releasePrNumber}`)
+
+    const releasePkgName = await octokit.rest.repos.getContent({
+      owner,
+      repo,
+      ref: baseBranch,
+      path: packagePath,
+    }).then(r => {
+      try {
+        return JSON.parse(Buffer.from(r.data.content, r.data.encoding)).name
+      } catch {
+        return null
+      }
+    })
+
+    if (!releasePkgName) {
+      throw new Error(`Could not find package name for release at: "${packagePath}#${baseBranch}"`)
+    }
+
+    logger.debug(`pkg name from ${packagePath}#${baseBranch}: "${releasePkgName}"`)
+
+    release.prNumber = releasePrNumber
+    release.pkgName = releasePkgName
+    if (isRoot) {
+      rootRelease = release
+    }
   }
 
   return {
-    pr: rootPr,
-    release: rootRelease,
+    pr: rootPr ?? null,
+    release: rootRelease ?? null,
     releases: releases.length ? releases : null,
   }
 }

--- a/lib/release-please/index.js
+++ b/lib/release-please/index.js
@@ -20,7 +20,18 @@ const omit = (obj, ...keys) => {
   return res
 }
 
-const getReleaseArtifacts = async ({ dryRun, github, baseBranch }) => {
+const getManifest = async ({ repo: fullRepo, token, branch }) => {
+  const fullRepoParts = fullRepo.split('/')
+  const github = await RP.GitHub.create({
+    owner: fullRepoParts[0],
+    repo: fullRepoParts[1],
+    token,
+  })
+
+  const { octokit, repository: { owner, repo, defaultBranch } } = github
+
+  const baseBranch = branch ?? defaultBranch
+
   // This is mostly for testing and debugging. Use environs with the
   // format `RELEASE_PLEASE_<manfiestOverrideConfigName>` (eg
   // `RELEASE_PLEASE_lastReleaseSha=<SHA>`) to set one-off config items
@@ -37,10 +48,56 @@ const getReleaseArtifacts = async ({ dryRun, github, baseBranch }) => {
     Object.fromEntries(manifestOverrides)
   )
 
-  let pullRequests
-  let releases
+  return {
+    github,
+    manifest,
+    octokit,
+    owner,
+    repo,
+    baseBranch,
+  }
+}
 
-  if (dryRun) {
+const getReleasesFromPr = async ({ manifest, github, number }) => {
+  const baseUrl = `https://github.com/${github.repository.owner}/${github.repository.repo}`
+  // get the release please formatted pull request
+  let pullRequest
+  const prGenerator = github.pullRequestIterator(this.targetBranch, 'MERGED', 200, false)
+  for await (const pr of prGenerator) {
+    if (pr.number === number) {
+      pullRequest = pr
+      break
+    }
+  }
+  const strategiesByPath = await manifest.getStrategiesByPath()
+  const releases = []
+  for (const path in manifest.repositoryConfig) {
+    const config = manifest.repositoryConfig[path]
+    const release = await strategiesByPath[path].buildRelease(pullRequest)
+    if (release) {
+      const { tag, ...rest } = release
+      releases.push({
+        ...rest,
+        ...tag.version,
+        tagName: tag.toString(),
+        version: tag.version.toString(),
+        path,
+        draft: false,
+        url: `${baseUrl}/releases/tag/${tag.toString()}`,
+        prerelease: config.prerelease && !!tag.version.preRelease,
+      })
+    }
+  }
+  return releases
+}
+
+const getReleaseArtifacts = async ({ dryRun, manifest, forceReleases }) => {
+  let pullRequests = []
+  let releases = []
+
+  if (forceReleases) {
+    releases = forceReleases
+  } else if (dryRun) {
     pullRequests = await manifest.buildPullRequests()
     releases = await manifest.buildReleases()
   } else {
@@ -54,26 +111,15 @@ const getReleaseArtifacts = async ({ dryRun, github, baseBranch }) => {
   }
 }
 
-const forcePullRequest = async ({ octokit, owner, repo, baseBranch }) => {
-  const { data: releasePrs } = await octokit.pulls.list({
-    owner,
-    repo,
-    head: `release-please--branches--${baseBranch}`,
-  })
-
-  if (releasePrs.length !== 1) {
-    throw new Error(`Found ${releasePrs.length} matching PRs, expected 1`)
-  }
-
-  const [releasePr] = releasePrs
+// XXX(hack): to get release please to recreate a pull request it needs
+// to have a different body string so we append a message a message that CI
+// is running. This will force release-please to rebase the PR but it
+// wont update the body again, so we only append to it.
+const touchPullRequest = async ({ octokit, owner, repo, releasePr }) => {
   const id = process.env.GITHUB_RUN_ID
     ? `by https://github.com/${owner}/${repo}/actions/runs/${process.env.GITHUB_RUN_ID}`
     : `manually starting at ${new Date().toJSON()}`
 
-  // XXX(hack): to get release please to recreate a pull request it needs
-  // to have a different body string so we append a message a message that CI
-  // is running. This will force release-please to rebase the PR but it
-  // wont update the body again, so we only append to it.
   await octokit.pulls.update({
     owner,
     repo,
@@ -82,33 +128,51 @@ const forcePullRequest = async ({ octokit, owner, repo, baseBranch }) => {
   })
 }
 
-const main = async ({ repo: _fullRepo, token, dryRun, branch, force }) => {
+const main = async ({ repo: fullRepo, token, dryRun, branch, forcePullRequest }) => {
   if (!token) {
     throw new Error('Token is required')
   }
 
-  if (!_fullRepo) {
+  if (!fullRepo) {
     throw new Error('Repo is required')
   }
 
-  const fullRepo = _fullRepo.split('/')
-  const github = await RP.GitHub.create({
-    owner: fullRepo[0],
-    repo: fullRepo[1],
-    token,
-  })
   const {
+    github,
     octokit,
-    repository: { owner, repo, defaultBranch },
-  } = github
+    manifest,
+    owner,
+    repo,
+    baseBranch,
+  } = await getManifest({ repo: fullRepo, token, branch })
 
-  const baseBranch = branch ?? defaultBranch
+  let forceReleases = null
 
-  if (force) {
-    await forcePullRequest({ octokit, owner, repo, baseBranch })
+  if (forcePullRequest) {
+    const { data: releasePr } = await octokit.rest.pulls.get({
+      owner,
+      repo,
+      pull_number: forcePullRequest,
+    })
+
+    if (!releasePr) {
+      throw new Error(`Could not find PR from number: ${forcePullRequest}`)
+    }
+
+    if (releasePr.state === 'open') {
+      await touchPullRequest({ octokit, owner, repo, releasePr })
+    } else if (releasePr.state === 'closed' && releasePr.merged) {
+      forceReleases = await getReleasesFromPr({ manifest, github, number: releasePr.number })
+    } else {
+      throw new Error(`Could not run workflow on PR with wrong state: ${JSON.stringify(
+        releasePr,
+        null,
+        2
+      )}`)
+    }
   }
 
-  const { pullRequests, releases } = await getReleaseArtifacts({ dryRun, github, baseBranch })
+  const { pullRequests, releases } = await getReleaseArtifacts({ dryRun, manifest, forceReleases })
 
   // We only ever get a single pull request with our current release-please settings
   // Update this if we start creating individual PRs per workspace release

--- a/tap-snapshots/test/apply/source-snapshots.js.test.cjs
+++ b/tap-snapshots/test/apply/source-snapshots.js.test.cjs
@@ -1049,14 +1049,17 @@ jobs:
             }
 
             const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number })
-            const releaseComments = comments.filter(c => c.user.login === 'github-actions[bot]' && c.body.includes('Release is at'))
+              .then(cs => cs.map(c => ({ id: c.id, login: c.user.login, body: c.body })))
+            console.log(\`Found comments: \${JSON.stringify(comments, null, 2)}\`)
+            const releaseComments = comments.filter(c => c.login === 'github-actions[bot]' && c.body.includes('Release is at'))
 
             for (const comment of releaseComments) {
+              console.log(\`Release comment: \${JSON.stringify(comment, null, 2)}\`)
               await github.rest.issues.deleteComment({ owner, repo, comment_id: comment.id })
             }
 
             const runUrl = \`https://github.com/\${owner}/\${repo}/actions/runs/\${runId}\`
-            await github.rest.issues.createComment({ 
+            await github.rest.issues.createComment({
               owner,
               repo,
               issue_number,
@@ -2631,14 +2634,17 @@ jobs:
             }
 
             const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number })
-            const releaseComments = comments.filter(c => c.user.login === 'github-actions[bot]' && c.body.includes('Release is at'))
+              .then(cs => cs.map(c => ({ id: c.id, login: c.user.login, body: c.body })))
+            console.log(\`Found comments: \${JSON.stringify(comments, null, 2)}\`)
+            const releaseComments = comments.filter(c => c.login === 'github-actions[bot]' && c.body.includes('Release is at'))
 
             for (const comment of releaseComments) {
+              console.log(\`Release comment: \${JSON.stringify(comment, null, 2)}\`)
               await github.rest.issues.deleteComment({ owner, repo, comment_id: comment.id })
             }
 
             const runUrl = \`https://github.com/\${owner}/\${repo}/actions/runs/\${runId}\`
-            await github.rest.issues.createComment({ 
+            await github.rest.issues.createComment({
               owner,
               repo,
               issue_number,
@@ -4056,14 +4062,17 @@ jobs:
             }
 
             const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number })
-            const releaseComments = comments.filter(c => c.user.login === 'github-actions[bot]' && c.body.includes('Release is at'))
+              .then(cs => cs.map(c => ({ id: c.id, login: c.user.login, body: c.body })))
+            console.log(\`Found comments: \${JSON.stringify(comments, null, 2)}\`)
+            const releaseComments = comments.filter(c => c.login === 'github-actions[bot]' && c.body.includes('Release is at'))
 
             for (const comment of releaseComments) {
+              console.log(\`Release comment: \${JSON.stringify(comment, null, 2)}\`)
               await github.rest.issues.deleteComment({ owner, repo, comment_id: comment.id })
             }
 
             const runUrl = \`https://github.com/\${owner}/\${repo}/actions/runs/\${runId}\`
-            await github.rest.issues.createComment({ 
+            await github.rest.issues.createComment({
               owner,
               repo,
               issue_number,

--- a/tap-snapshots/test/apply/source-snapshots.js.test.cjs
+++ b/tap-snapshots/test/apply/source-snapshots.js.test.cjs
@@ -758,6 +758,10 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      release-pr:
+        description: a release PR number to rerun release jobs on
+        type: string
   push:
     branches:
       - main
@@ -807,7 +811,7 @@ jobs:
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
         run: |
-          npx --offline template-oss-release-please \${{ github.ref_name }} \${{ github.event_name }}
+          npx --offline template-oss-release-please "\${{ github.ref_name }}" "\${{ inputs.release-pr }}"
       - name: Post Pull Request Comment
         if: steps.release.outputs.pr-number
         uses: actions/github-script@v6
@@ -830,7 +834,7 @@ jobs:
             body += \`Release workflow run: \${workflow.html_url}/n/n#### Force CI to Update This Release/n/n\`
             body += \`This PR will be updated and CI will run for every non-/\`chore:/\` commit that is pushed to /\`main/\`. \`
             body += \`To force CI to update this PR, run this command:/n/n\`
-            body += \`/\`/\`/\`/ngh workflow run release.yml -r \${REF_NAME} -R \${owner}/\${repo}/n/\`/\`/\`\`
+            body += \`/\`/\`/\`/ngh workflow run release.yml -r \${REF_NAME} -R \${owner}/\${repo} -f release-pr=\${issue_number}/n/\`/\`/\`\`
 
             if (commentId) {
               await github.rest.issues.updateComment({ owner, repo, comment_id: commentId, body })
@@ -1132,10 +1136,14 @@ jobs:
         with:
           script: |
             const { PR_NUMBER: issue_number, RESULT } = process.env
-            const { repo: { owner, repo } } = context
+            const { runId, repo: { owner, repo } } = context
 
             const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number })
-            const updateComment = comments.find(c => c.user.login === 'github-actions[bot]' && c.body.startsWith('## Release Workflow/n/n'))
+            const updateComment = comments.find(c =>
+              c.user.login === 'github-actions[bot]' &&
+              c.body.startsWith('## Release Workflow/n/n') &&
+              c.body.includes(runId)
+            )
 
             if (updateComment) {
               console.log('Found comment to update:', JSON.stringify(updateComment, null, 2))
@@ -2332,6 +2340,10 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      release-pr:
+        description: a release PR number to rerun release jobs on
+        type: string
   push:
     branches:
       - main
@@ -2381,7 +2393,7 @@ jobs:
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
         run: |
-          npx --offline template-oss-release-please \${{ github.ref_name }} \${{ github.event_name }}
+          npx --offline template-oss-release-please "\${{ github.ref_name }}" "\${{ inputs.release-pr }}"
       - name: Post Pull Request Comment
         if: steps.release.outputs.pr-number
         uses: actions/github-script@v6
@@ -2404,7 +2416,7 @@ jobs:
             body += \`Release workflow run: \${workflow.html_url}/n/n#### Force CI to Update This Release/n/n\`
             body += \`This PR will be updated and CI will run for every non-/\`chore:/\` commit that is pushed to /\`main/\`. \`
             body += \`To force CI to update this PR, run this command:/n/n\`
-            body += \`/\`/\`/\`/ngh workflow run release.yml -r \${REF_NAME} -R \${owner}/\${repo}/n/\`/\`/\`\`
+            body += \`/\`/\`/\`/ngh workflow run release.yml -r \${REF_NAME} -R \${owner}/\${repo} -f release-pr=\${issue_number}/n/\`/\`/\`\`
 
             if (commentId) {
               await github.rest.issues.updateComment({ owner, repo, comment_id: commentId, body })
@@ -2706,10 +2718,14 @@ jobs:
         with:
           script: |
             const { PR_NUMBER: issue_number, RESULT } = process.env
-            const { repo: { owner, repo } } = context
+            const { runId, repo: { owner, repo } } = context
 
             const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number })
-            const updateComment = comments.find(c => c.user.login === 'github-actions[bot]' && c.body.startsWith('## Release Workflow/n/n'))
+            const updateComment = comments.find(c =>
+              c.user.login === 'github-actions[bot]' &&
+              c.body.startsWith('## Release Workflow/n/n') &&
+              c.body.includes(runId)
+            )
 
             if (updateComment) {
               console.log('Found comment to update:', JSON.stringify(updateComment, null, 2))
@@ -3749,6 +3765,10 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      release-pr:
+        description: a release PR number to rerun release jobs on
+        type: string
   push:
     branches:
       - main
@@ -3798,7 +3818,7 @@ jobs:
         env:
           GITHUB_TOKEN: \${{ secrets.GITHUB_TOKEN }}
         run: |
-          npx --offline template-oss-release-please \${{ github.ref_name }} \${{ github.event_name }}
+          npx --offline template-oss-release-please "\${{ github.ref_name }}" "\${{ inputs.release-pr }}"
       - name: Post Pull Request Comment
         if: steps.release.outputs.pr-number
         uses: actions/github-script@v6
@@ -3821,7 +3841,7 @@ jobs:
             body += \`Release workflow run: \${workflow.html_url}/n/n#### Force CI to Update This Release/n/n\`
             body += \`This PR will be updated and CI will run for every non-/\`chore:/\` commit that is pushed to /\`main/\`. \`
             body += \`To force CI to update this PR, run this command:/n/n\`
-            body += \`/\`/\`/\`/ngh workflow run release.yml -r \${REF_NAME} -R \${owner}/\${repo}/n/\`/\`/\`\`
+            body += \`/\`/\`/\`/ngh workflow run release.yml -r \${REF_NAME} -R \${owner}/\${repo} -f release-pr=\${issue_number}/n/\`/\`/\`\`
 
             if (commentId) {
               await github.rest.issues.updateComment({ owner, repo, comment_id: commentId, body })
@@ -4123,10 +4143,14 @@ jobs:
         with:
           script: |
             const { PR_NUMBER: issue_number, RESULT } = process.env
-            const { repo: { owner, repo } } = context
+            const { runId, repo: { owner, repo } } = context
 
             const comments = await github.paginate(github.rest.issues.listComments, { owner, repo, issue_number })
-            const updateComment = comments.find(c => c.user.login === 'github-actions[bot]' && c.body.startsWith('## Release Workflow/n/n'))
+            const updateComment = comments.find(c =>
+              c.user.login === 'github-actions[bot]' &&
+              c.body.startsWith('## Release Workflow/n/n') &&
+              c.body.includes(runId)
+            )
 
             if (updateComment) {
               console.log('Found comment to update:', JSON.stringify(updateComment, null, 2))


### PR DESCRIPTION
This adds logging to the release-please workflow step to get a better idea of what is causing some of the transient failures we've seen in that job.

Ref https://github.com/npm/stafftools/actions/runs/4109009588/jobs/7090345220#step:8:121
Ref https://github.com/npm/cli/actions/runs/4071227938/jobs/7012840616#step:6:805