### PR TITLE
feat: add probot settings template

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,35 @@
+# This file is automatically added by @npmcli/template-oss. Do not edit.
+
+repository:
+  allow_merge_commit: false
+  allow_rebase_merge: true
+  allow_squash_merge: true
+  squash_merge_commit_title: PR_TITLE
+  squash_merge_commit_message: PR_BODY
+  delete_branch_on_merge: true
+  enable_automated_security_fixes: true
+  enable_vulnerability_alerts: true
+
+branches:
+  - name: main
+    protection:
+      required_pull_request_reviews:
+        required_pull_request_review_count: 1
+        dismiss_stale_reviews: true
+        require_code_owner_reviews: true
+      restrictions:
+        teams:
+          - "npm/cli-team"
+      enforce_admins: true
+      required_status_checks: null
+  - name: latest
+    protection:
+      required_pull_request_reviews:
+        required_pull_request_review_count: 1
+        dismiss_stale_reviews: true
+        require_code_owner_reviews: true
+      restrictions:
+        teams:
+          - "npm/cli-team"
+      enforce_admins: true
+      required_status_checks: null

--- a/lib/content/index.js
+++ b/lib/content/index.js
@@ -49,6 +49,9 @@ const sharedRootAdd = (name) => ({
   '.github/workflows/post-dependabot.yml': {
     file: 'post-dependabot.yml',
   },
+  '.github/settings.yml': {
+    file: 'settings.yml',
+  },
 })
 
 const sharedRootRm = () => ({

--- a/lib/content/settings.yml
+++ b/lib/content/settings.yml
@@ -1,0 +1,24 @@
+repository:
+  allow_merge_commit: false
+  allow_rebase_merge: true
+  allow_squash_merge: true
+  squash_merge_commit_title: PR_TITLE
+  squash_merge_commit_message: PR_BODY
+  delete_branch_on_merge: true
+  enable_automated_security_fixes: true
+  enable_vulnerability_alerts: true
+
+branches:
+  {{#each branches}}
+  - name: {{ . }}
+    protection:
+      required_pull_request_reviews:
+        required_pull_request_review_count: 1
+        dismiss_stale_reviews: true
+        require_code_owner_reviews: true
+      restrictions:
+        teams:
+          - "npm/cli-team"
+      enforce_admins: true
+      required_status_checks: null
+  {{/each}}

--- a/tap-snapshots/test/apply/files-snapshots.js.test.cjs
+++ b/tap-snapshots/test/apply/files-snapshots.js.test.cjs
@@ -13,6 +13,7 @@ exports[`test/apply/files-snapshots.js TAP private workspace > expect resolving 
 .github/ISSUE_TEMPLATE/bug.yml
 .github/ISSUE_TEMPLATE/config.yml
 .github/matchers/tap.json
+.github/settings.yml
 .github/workflows/audit.yml
 .github/workflows/ci-a.yml
 .github/workflows/ci-b.yml
@@ -44,6 +45,7 @@ exports[`test/apply/files-snapshots.js TAP turn off add/rm types > expect resolv
 .github/ISSUE_TEMPLATE/bug.yml
 .github/ISSUE_TEMPLATE/config.yml
 .github/matchers/tap.json
+.github/settings.yml
 .github/workflows/audit.yml
 .github/workflows/ci-release.yml
 .github/workflows/ci.yml
@@ -63,6 +65,7 @@ exports[`test/apply/files-snapshots.js TAP turn off module > expect resolving Pr
 .github/ISSUE_TEMPLATE/bug.yml
 .github/ISSUE_TEMPLATE/config.yml
 .github/matchers/tap.json
+.github/settings.yml
 .github/workflows/audit.yml
 .github/workflows/ci-release.yml
 .github/workflows/ci.yml
@@ -95,6 +98,7 @@ exports[`test/apply/files-snapshots.js TAP turn off specific files > expect reso
 .github/ISSUE_TEMPLATE/bug.yml
 .github/ISSUE_TEMPLATE/config.yml
 .github/matchers/tap.json
+.github/settings.yml
 .github/workflows/audit.yml
 .github/workflows/ci-release.yml
 .github/workflows/ci.yml
@@ -115,6 +119,7 @@ SECURITY.md
 exports[`test/apply/files-snapshots.js TAP workspaces > expect resolving Promise 1`] = `
 .github/dependabot.yml
 .github/matchers/tap.json
+.github/settings.yml
 .github/workflows/ci-d.yml
 .github/workflows/ci-release.yml
 .github/workflows/post-dependabot.yml
@@ -138,6 +143,7 @@ workspaces/d/package.json
 exports[`test/apply/files-snapshots.js TAP workspaces only (like npm/cli) > expect resolving Promise 1`] = `
 .github/dependabot.yml
 .github/matchers/tap.json
+.github/settings.yml
 .github/workflows/ci-a.yml
 .github/workflows/ci-b.yml
 .github/workflows/ci-release.yml

--- a/tap-snapshots/test/apply/source-snapshots.js.test.cjs
+++ b/tap-snapshots/test/apply/source-snapshots.js.test.cjs
@@ -163,6 +163,44 @@ blank_issues_enabled: true
   ]
 }
 
+.github/settings.yml
+========================================
+# This file is automatically added by @npmcli/template-oss. Do not edit.
+
+repository:
+  allow_merge_commit: false
+  allow_rebase_merge: true
+  allow_squash_merge: true
+  squash_merge_commit_title: PR_TITLE
+  squash_merge_commit_message: PR_BODY
+  delete_branch_on_merge: true
+  enable_automated_security_fixes: true
+  enable_vulnerability_alerts: true
+
+branches:
+  - name: main
+    protection:
+      required_pull_request_reviews:
+        required_pull_request_review_count: 1
+        dismiss_stale_reviews: true
+        require_code_owner_reviews: true
+      restrictions:
+        teams:
+          - "npm/cli-team"
+      enforce_admins: true
+      required_status_checks: null
+  - name: latest
+    protection:
+      required_pull_request_reviews:
+        required_pull_request_review_count: 1
+        dismiss_stale_reviews: true
+        require_code_owner_reviews: true
+      restrictions:
+        teams:
+          - "npm/cli-team"
+      enforce_admins: true
+      required_status_checks: null
+
 .github/workflows/audit.yml
 ========================================
 # This file is automatically added by @npmcli/template-oss. Do not edit.
@@ -1515,6 +1553,44 @@ blank_issues_enabled: true
     }
   ]
 }
+
+.github/settings.yml
+========================================
+# This file is automatically added by @npmcli/template-oss. Do not edit.
+
+repository:
+  allow_merge_commit: false
+  allow_rebase_merge: true
+  allow_squash_merge: true
+  squash_merge_commit_title: PR_TITLE
+  squash_merge_commit_message: PR_BODY
+  delete_branch_on_merge: true
+  enable_automated_security_fixes: true
+  enable_vulnerability_alerts: true
+
+branches:
+  - name: main
+    protection:
+      required_pull_request_reviews:
+        required_pull_request_review_count: 1
+        dismiss_stale_reviews: true
+        require_code_owner_reviews: true
+      restrictions:
+        teams:
+          - "npm/cli-team"
+      enforce_admins: true
+      required_status_checks: null
+  - name: latest
+    protection:
+      required_pull_request_reviews:
+        required_pull_request_review_count: 1
+        dismiss_stale_reviews: true
+        require_code_owner_reviews: true
+      restrictions:
+        teams:
+          - "npm/cli-team"
+      enforce_admins: true
+      required_status_checks: null
 
 .github/workflows/audit.yml
 ========================================
@@ -3144,6 +3220,44 @@ updates:
     }
   ]
 }
+
+.github/settings.yml
+========================================
+# This file is automatically added by @npmcli/template-oss. Do not edit.
+
+repository:
+  allow_merge_commit: false
+  allow_rebase_merge: true
+  allow_squash_merge: true
+  squash_merge_commit_title: PR_TITLE
+  squash_merge_commit_message: PR_BODY
+  delete_branch_on_merge: true
+  enable_automated_security_fixes: true
+  enable_vulnerability_alerts: true
+
+branches:
+  - name: main
+    protection:
+      required_pull_request_reviews:
+        required_pull_request_review_count: 1
+        dismiss_stale_reviews: true
+        require_code_owner_reviews: true
+      restrictions:
+        teams:
+          - "npm/cli-team"
+      enforce_admins: true
+      required_status_checks: null
+  - name: latest
+    protection:
+      required_pull_request_reviews:
+        required_pull_request_review_count: 1
+        dismiss_stale_reviews: true
+        require_code_owner_reviews: true
+      restrictions:
+        teams:
+          - "npm/cli-team"
+      enforce_admins: true
+      required_status_checks: null
 
 .github/workflows/ci-a.yml
 ========================================

--- a/tap-snapshots/test/check/snapshots.js.test.cjs
+++ b/tap-snapshots/test/check/snapshots.js.test.cjs
@@ -35,6 +35,7 @@ The following repo files need to be added:
   .github/ISSUE_TEMPLATE/bug.yml
   .github/ISSUE_TEMPLATE/config.yml
   .github/matchers/tap.json
+  .github/settings.yml
   .github/workflows/audit.yml
   .github/workflows/ci-release.yml
   .github/workflows/ci.yml
@@ -282,6 +283,7 @@ The following repo files need to be added:
   .github/ISSUE_TEMPLATE/bug.yml
   .github/ISSUE_TEMPLATE/config.yml
   .github/matchers/tap.json
+  .github/settings.yml
   .github/workflows/audit.yml
   .github/workflows/ci-release.yml
   .github/workflows/ci.yml
@@ -365,6 +367,7 @@ The following repo files need to be added:
 
   .github/dependabot.yml
   .github/matchers/tap.json
+  .github/settings.yml
   .github/workflows/ci-name-aaaa.yml
   .github/workflows/ci-release.yml
   .github/workflows/post-dependabot.yml
@@ -436,6 +439,7 @@ The following repo files need to be added:
 
   .github/dependabot.yml
   .github/matchers/tap.json
+  .github/settings.yml
   .github/workflows/ci-bbb.yml
   .github/workflows/ci-release.yml
   .github/workflows/post-dependabot.yml


### PR DESCRIPTION
this settings file is intended to setup our merge strategy as well as branch protections, and is the first step in maintaining repo settings as code.

in order for this file to take effect, the probot settings app must be installed and enabled for the repo: https://github.com/apps/settings

for #98
