### PR TITLE
chore: do not sign commits in tests

### DIFF
--- a/test/setup.js
+++ b/test/setup.js
@@ -150,7 +150,7 @@ const setupGit = async (...args) => {
 
   const gca = async () => {
     await git('add -A .')
-    await git('commit -m "init"')
+    await git('commit --no-gpg-sign -m "init"')
   }
 
   await git('init')


### PR DESCRIPTION
currently running the tests creates git repos and commits using your default git configuration. for me personally, this means that i get a popup confirming the signing request for these commits since i have my git configured to always sign. this means when running tests, i get a lot of notifications. by forcibly telling git to _not_ sign these commits, this no longer happens, and since signatures are not important for test fixtures that are being discarded anyway felt like a quick usability win here.
