### PR TITLE
fix: do not allow importing dev dependencies from src

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,4 +17,16 @@ module.exports = {
     '@npmcli',
     ...localConfigs,
   ],
+  rules: {
+    'import/no-extraneous-dependencies': ['error', { devDependencies: false }],
+  },
+  overrides: [
+    {
+      files: ['**/test/**', '.eslintrc.js', '.eslintrc.local.js'],
+      rules: {
+        // back to default options
+        'import/no-extraneous-dependencies': ['error', {}],
+      },
+    },
+  ],
 }

--- a/lib/content/eslintrc.js
+++ b/lib/content/eslintrc.js
@@ -19,4 +19,16 @@ module.exports = {
     '@npmcli',
     ...localConfigs,
   ],
+  rules: {
+    'import/no-extraneous-dependencies': ['error', { devDependencies: false }],
+  },
+  overrides: [
+    {
+      files: ['**/test/**', '.eslintrc.js', '.eslintrc.local.js'],
+      rules: {
+        // back to default options
+        'import/no-extraneous-dependencies': ['error', {}],
+      },
+    },
+  ],
 }

--- a/tap-snapshots/test/apply/source-snapshots.js.test.cjs
+++ b/tap-snapshots/test/apply/source-snapshots.js.test.cjs
@@ -37,6 +37,18 @@ module.exports = {
     '@npmcli',
     ...localConfigs,
   ],
+  rules: {
+    'import/no-extraneous-dependencies': ['error', { devDependencies: false }],
+  },
+  overrides: [
+    {
+      files: ['**/test/**', '.eslintrc.js', '.eslintrc.local.js'],
+      rules: {
+        // back to default options
+        'import/no-extraneous-dependencies': ['error', {}],
+      },
+    },
+  ],
 }
 
 .github/CODEOWNERS
@@ -1448,6 +1460,18 @@ module.exports = {
   extends: [
     '@npmcli',
     ...localConfigs,
+  ],
+  rules: {
+    'import/no-extraneous-dependencies': ['error', { devDependencies: false }],
+  },
+  overrides: [
+    {
+      files: ['**/test/**', '.eslintrc.js', '.eslintrc.local.js'],
+      rules: {
+        // back to default options
+        'import/no-extraneous-dependencies': ['error', {}],
+      },
+    },
   ],
 }
 
@@ -3104,6 +3128,18 @@ module.exports = {
     '@npmcli',
     ...localConfigs,
   ],
+  rules: {
+    'import/no-extraneous-dependencies': ['error', { devDependencies: false }],
+  },
+  overrides: [
+    {
+      files: ['**/test/**', '.eslintrc.js', '.eslintrc.local.js'],
+      rules: {
+        // back to default options
+        'import/no-extraneous-dependencies': ['error', {}],
+      },
+    },
+  ],
 }
 
 workspaces/a/.gitignore
@@ -3181,6 +3217,18 @@ module.exports = {
   extends: [
     '@npmcli',
     ...localConfigs,
+  ],
+  rules: {
+    'import/no-extraneous-dependencies': ['error', { devDependencies: false }],
+  },
+  overrides: [
+    {
+      files: ['**/test/**', '.eslintrc.js', '.eslintrc.local.js'],
+      rules: {
+        // back to default options
+        'import/no-extraneous-dependencies': ['error', {}],
+      },
+    },
   ],
 }
 
@@ -4463,6 +4511,18 @@ module.exports = {
     '@npmcli',
     ...localConfigs,
   ],
+  rules: {
+    'import/no-extraneous-dependencies': ['error', { devDependencies: false }],
+  },
+  overrides: [
+    {
+      files: ['**/test/**', '.eslintrc.js', '.eslintrc.local.js'],
+      rules: {
+        // back to default options
+        'import/no-extraneous-dependencies': ['error', {}],
+      },
+    },
+  ],
 }
 
 workspaces/a/.gitignore
@@ -4540,6 +4600,18 @@ module.exports = {
   extends: [
     '@npmcli',
     ...localConfigs,
+  ],
+  rules: {
+    'import/no-extraneous-dependencies': ['error', { devDependencies: false }],
+  },
+  overrides: [
+    {
+      files: ['**/test/**', '.eslintrc.js', '.eslintrc.local.js'],
+      rules: {
+        // back to default options
+        'import/no-extraneous-dependencies': ['error', {}],
+      },
+    },
   ],
 }
 

--- a/workspace/test-workspace/.eslintrc.js
+++ b/workspace/test-workspace/.eslintrc.js
@@ -14,4 +14,16 @@ module.exports = {
     '@npmcli',
     ...localConfigs,
   ],
+  rules: {
+    'import/no-extraneous-dependencies': ['error', { devDependencies: false }],
+  },
+  overrides: [
+    {
+      files: ['**/test/**', '.eslintrc.js', '.eslintrc.local.js'],
+      rules: {
+        // back to default options
+        'import/no-extraneous-dependencies': ['error', {}],
+      },
+    },
+  ],
 }


### PR DESCRIPTION
See https://github.com/npm/node-semver/pull/559#discussion_r1186551497

Not sure if this needs to be opt-in, or if it can apply to all projects using this?

## References
Needed by https://github.com/npm/node-semver/pull/559
