### PR TITLE
Features for landing template-oss in older packages

### DIFF
--- a/.github/workflows/ci-test-workspace.yml
+++ b/.github/workflows/ci-test-workspace.yml
@@ -11,6 +11,7 @@ on:
     branches:
       - main
       - latest
+      - release/v*
     paths:
       - workspace/test-workspace/**
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
     branches:
       - main
       - latest
+      - release/v*
     paths-ignore:
       - workspace/test-workspace/**
   schedule:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,10 +7,12 @@ on:
     branches:
       - main
       - latest
+      - release/v*
   pull_request:
     branches:
       - main
       - latest
+      - release/v*
   schedule:
     # "At 10:00 UTC (03:00 PT) on Monday" https://crontab.guru/#0_10_*_*_1
     - cron: "0 10 * * 1"

--- a/lib/config.js
+++ b/lib/config.js
@@ -228,9 +228,11 @@ const getFullConfig = async ({
 
   if (pkgConfig.ciVersions) {
     let versions = pkgConfig.ciVersions
-    if (versions === 'latest') {
-      const defaultVersions = [rootPkgConfig, defaultConfig].find(c => Array.isArray(c.ciVersions))
-      versions = defaultVersions.ciVersions.slice(-1)
+    if (versions === 'latest' || (Array.isArray(versions) && versions.includes('latest'))) {
+      const { ciVersions } = [isWorkspace ? rootPkgConfig : {}, defaultConfig]
+        .find(c => Array.isArray(c.ciVersions))
+      const defaultLatest = ciVersions[ciVersions.length - 1]
+      versions = [].concat(versions).map(v => v === 'latest' ? defaultLatest : v)
     }
 
     const { targets, engines } = parseCIVersions(versions)

--- a/lib/config.js
+++ b/lib/config.js
@@ -251,6 +251,14 @@ const getFullConfig = async ({
     derived.engines = pkgConfig.engines || engines
   }
 
+  if (!pkgConfig.eslint) {
+    derived.ignorePaths = derived.ignorePaths.filter(p => !p.includes('eslint'))
+    if (Array.isArray(pkgConfig.requiredPackages?.devDependencies)) {
+      pkgConfig.requiredPackages.devDependencies =
+        pkgConfig.requiredPackages.devDependencies.filter(p => !p.includes('eslint'))
+    }
+  }
+
   const gitUrl = await getGitUrl(rootPkg.path)
   if (gitUrl) {
     derived.repository = {

--- a/lib/config.js
+++ b/lib/config.js
@@ -195,7 +195,7 @@ const getFullConfig = async ({
     isLatest,
     // whether to install and update npm in ci
     // only do this if we aren't using a custom path to bin
-    updateNpm: !npmPath.isLocal,
+    updateNpm: !npmPath.isLocal && pkgConfig.updateNpm,
     rootNpmPath: npmPath.root,
     localNpmPath: npmPath.local,
     rootNpxPath: npxPath.root,

--- a/lib/content/index.js
+++ b/lib/content/index.js
@@ -131,7 +131,7 @@ module.exports = {
   workspaceModule,
   windowsCI: true,
   macCI: true,
-  branches: ['main', 'latest'],
+  branches: ['main', 'latest', 'release/v*'],
   defaultBranch: 'main',
   distPaths: [
     'bin/',

--- a/lib/content/index.js
+++ b/lib/content/index.js
@@ -159,6 +159,7 @@ module.exports = {
   npm: 'npm',
   npx: 'npx',
   npmSpec: 'latest',
+  updateNpm: true,
   dependabot: 'increase-if-necessary',
   unwantedPackages: [
     'eslint',

--- a/lib/content/index.js
+++ b/lib/content/index.js
@@ -85,7 +85,10 @@ const rootRepo = {
 // dir. so we might want to combine these
 const rootModule = {
   add: {
-    '.eslintrc.js': 'eslintrc.js',
+    '.eslintrc.js': {
+      file: 'eslintrc.js',
+      filter: (p) => p.config.eslint,
+    },
     '.gitignore': 'gitignore',
     '.npmrc': 'npmrc',
     'SECURITY.md': 'SECURITY.md',
@@ -113,7 +116,10 @@ const workspaceRepo = {
 // Changes for each workspace but applied to the relative workspace dir
 const workspaceModule = {
   add: {
-    '.eslintrc.js': 'eslintrc.js',
+    '.eslintrc.js': {
+      file: 'eslintrc.js',
+      filter: (p) => p.config.eslint,
+    },
     '.gitignore': 'gitignore',
     'package.json': 'pkg.json',
   },
@@ -155,6 +161,7 @@ module.exports = {
   ciVersions: ['14.17.0', '14.x', '16.13.0', '16.x', '18.0.0', '18.x'],
   lockfile: false,
   codeowner: '@npm/cli-team',
+  eslint: true,
   publish: false,
   npm: 'npm',
   npx: 'npx',

--- a/lib/content/pkg.json
+++ b/lib/content/pkg.json
@@ -2,7 +2,7 @@
   "author": "GitHub Inc.",
   "files": {{{ json distPaths }}},
   "scripts": {
-    "lint": "eslint \"**/*.js\"",
+    "lint": "{{#if eslint}}eslint \"**/*.js\"{{else}}echo linting disabled{{/if}}",
     "postlint": "template-oss-check",
     "template-oss-apply": "template-oss-apply --force",
     "lintfix": "{{ localNpmPath }} run lint -- --fix",

--- a/lib/content/release.yml
+++ b/lib/content/release.yml
@@ -11,7 +11,6 @@ on:
       {{#each branches}}
       - {{ . }}
       {{/each}}
-      - release/v*
 
 permissions:
   contents: write

--- a/tap-snapshots/test/apply/source-snapshots.js.test.cjs
+++ b/tap-snapshots/test/apply/source-snapshots.js.test.cjs
@@ -466,6 +466,7 @@ on:
     branches:
       - main
       - latest
+      - release/v*
   schedule:
     # "At 09:00 UTC (02:00 PT) on Monday" https://crontab.guru/#0_9_*_*_1
     - cron: "0 9 * * 1"
@@ -574,10 +575,12 @@ on:
     branches:
       - main
       - latest
+      - release/v*
   pull_request:
     branches:
       - main
       - latest
+      - release/v*
   schedule:
     # "At 10:00 UTC (03:00 PT) on Monday" https://crontab.guru/#0_10_*_*_1
     - cron: "0 10 * * 1"
@@ -1685,6 +1688,7 @@ on:
     branches:
       - main
       - latest
+      - release/v*
     paths:
       - workspaces/a/**
   schedule:
@@ -1799,6 +1803,7 @@ on:
     branches:
       - main
       - latest
+      - release/v*
     paths:
       - workspaces/b/**
   schedule:
@@ -2133,6 +2138,7 @@ on:
     branches:
       - main
       - latest
+      - release/v*
     paths-ignore:
       - workspaces/a/**
       - workspaces/b/**
@@ -2244,10 +2250,12 @@ on:
     branches:
       - main
       - latest
+      - release/v*
   pull_request:
     branches:
       - main
       - latest
+      - release/v*
   schedule:
     # "At 10:00 UTC (03:00 PT) on Monday" https://crontab.guru/#0_10_*_*_1
     - cron: "0 10 * * 1"
@@ -3355,6 +3363,7 @@ on:
     branches:
       - main
       - latest
+      - release/v*
     paths:
       - workspaces/a/**
   schedule:
@@ -3469,6 +3478,7 @@ on:
     branches:
       - main
       - latest
+      - release/v*
     paths:
       - workspaces/b/**
   schedule:

--- a/tap-snapshots/test/check/diff-snapshots.js.test.cjs
+++ b/tap-snapshots/test/check/diff-snapshots.js.test.cjs
@@ -173,7 +173,7 @@ The repo file ci.yml needs to be updated:
 
   .github/workflows/ci.yml
   ========================================
-  @@ -83,5 +83,25 @@
+  @@ -84,5 +84,25 @@
              node-version: \${{ matrix.node-version }}
          - name: Update Windows npm
            # node 12 and 14 ship with npm@6, which is known to fail when updating itself in windows

--- a/test/apply/engines.js
+++ b/test/apply/engines.js
@@ -20,6 +20,26 @@ t.test('can set engines and ci separately', async (t) => {
   t.notOk(ci.includes('- 12'))
 })
 
+t.test('can set ci to latest plus other versions', async (t) => {
+  const s = await setup(t, {
+    package: {
+      templateOSS: {
+        ciVersions: ['6', '8', 'latest'],
+        engines: '*',
+      },
+    },
+  })
+  await s.apply()
+
+  const pkg = await s.readJson('package.json')
+  const ci = await s.readFile(join('.github', 'workflows', 'ci.yml'))
+
+  t.equal(pkg.engines.node, '*')
+  t.ok(ci.includes('- 6'))
+  t.ok(ci.includes('- 8'))
+  t.ok(ci.includes('- 18.x'))
+})
+
 t.test('latest ci versions', async (t) => {
   const s = await setup(t, {
     package: {

--- a/test/apply/eslint.js
+++ b/test/apply/eslint.js
@@ -1,0 +1,24 @@
+const t = require('tap')
+const setup = require('../setup.js')
+
+t.test('can disable eslint', async (t) => {
+  const s = await setup(t, {
+    package: {
+      templateOSS: {
+        eslint: false,
+      },
+    },
+  })
+  await s.apply()
+
+  const pkg = await s.readJson('package.json')
+  delete pkg.templateOSS // templateOSS config has eslint in it
+  t.notMatch(JSON.stringify(pkg), 'eslint')
+
+  const gitignore = await s.readFile('.gitignore')
+  t.notMatch(gitignore, 'eslint')
+
+  const checks = await s.check()
+  t.equal(checks.length, 1)
+  t.notMatch(checks[0].solution, 'eslint')
+})


### PR DESCRIPTION
This PR contains the following commits which add config options to make landing template-oss easier in older packages.

- feat: add release/v branches to all branch CI
- feat: add config option to not update npm
- feat: add config option to disable eslint
- feat: allow adding latest to other ci versions





