### PR TITLE
fix: block protected branch creations

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -15,6 +15,7 @@ branches:
     protection:
       required_status_checks: null
       enforce_admins: true
+      block_creations: true
       required_pull_request_reviews:
         required_approving_review_count: 1
         require_code_owner_reviews: true
@@ -28,6 +29,7 @@ branches:
     protection:
       required_status_checks: null
       enforce_admins: true
+      block_creations: true
       required_pull_request_reviews:
         required_approving_review_count: 1
         require_code_owner_reviews: true
@@ -41,6 +43,7 @@ branches:
     protection:
       required_status_checks: null
       enforce_admins: true
+      block_creations: true
       required_pull_request_reviews:
         required_approving_review_count: 1
         require_code_owner_reviews: true

--- a/lib/content/settings.yml
+++ b/lib/content/settings.yml
@@ -14,6 +14,7 @@ branches:
     protection:
       required_status_checks: null
       enforce_admins: true
+      block_creations: true
       required_pull_request_reviews:
         required_approving_review_count: 1
         require_code_owner_reviews: true

--- a/tap-snapshots/test/apply/source-snapshots.js.test.cjs
+++ b/tap-snapshots/test/apply/source-snapshots.js.test.cjs
@@ -182,6 +182,7 @@ branches:
     protection:
       required_status_checks: null
       enforce_admins: true
+      block_creations: true
       required_pull_request_reviews:
         required_approving_review_count: 1
         require_code_owner_reviews: true
@@ -195,6 +196,7 @@ branches:
     protection:
       required_status_checks: null
       enforce_admins: true
+      block_creations: true
       required_pull_request_reviews:
         required_approving_review_count: 1
         require_code_owner_reviews: true
@@ -208,6 +210,7 @@ branches:
     protection:
       required_status_checks: null
       enforce_admins: true
+      block_creations: true
       required_pull_request_reviews:
         required_approving_review_count: 1
         require_code_owner_reviews: true
@@ -1647,6 +1650,7 @@ branches:
     protection:
       required_status_checks: null
       enforce_admins: true
+      block_creations: true
       required_pull_request_reviews:
         required_approving_review_count: 1
         require_code_owner_reviews: true
@@ -1660,6 +1664,7 @@ branches:
     protection:
       required_status_checks: null
       enforce_admins: true
+      block_creations: true
       required_pull_request_reviews:
         required_approving_review_count: 1
         require_code_owner_reviews: true
@@ -1673,6 +1678,7 @@ branches:
     protection:
       required_status_checks: null
       enforce_admins: true
+      block_creations: true
       required_pull_request_reviews:
         required_approving_review_count: 1
         require_code_owner_reviews: true
@@ -3390,6 +3396,7 @@ branches:
     protection:
       required_status_checks: null
       enforce_admins: true
+      block_creations: true
       required_pull_request_reviews:
         required_approving_review_count: 1
         require_code_owner_reviews: true
@@ -3403,6 +3410,7 @@ branches:
     protection:
       required_status_checks: null
       enforce_admins: true
+      block_creations: true
       required_pull_request_reviews:
         required_approving_review_count: 1
         require_code_owner_reviews: true
@@ -3416,6 +3424,7 @@ branches:
     protection:
       required_status_checks: null
       enforce_admins: true
+      block_creations: true
       required_pull_request_reviews:
         required_approving_review_count: 1
         require_code_owner_reviews: true


### PR DESCRIPTION
Now that we use a wildcard to match against release branches for
backports, creation of those branches should also be locked down to
admins only.
