### PR TITLE
fix: install npm in CI based on node version

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -25,10 +25,54 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ..\npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: ${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -80,10 +80,54 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ..\npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: ${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -181,11 +225,17 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: ${{ matrix.node-version }}
+          check-latest: contains(matrix.node-version, '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
       - name: Update Windows npm
-        # node 12 and 14 ship with npm@6, which is known to fail when updating itself in windows
-        if: matrix.platform.os == 'windows-latest' && (startsWith(matrix.node-version, '12.') || startsWith(matrix.node-version, '14.'))
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
         run: |
           curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
           tar xf npm-7.5.4.tgz
@@ -193,12 +243,36 @@ jobs:
           node lib/npm.js install --no-fund --no-audit -g ..\npm-7.5.4.tgz
           cd ..
           rmdir /s /q package
-      - name: Install npm@7
-        if: startsWith(matrix.node-version, '10.')
-        run: npm i --prefer-online --no-fund --no-audit -g npm@7
-      - name: Install npm@latest
-        if: ${{ !startsWith(matrix.node-version, '10.') }}
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: ${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies

--- a/.github/workflows/ci-test-workspace.yml
+++ b/.github/workflows/ci-test-workspace.yml
@@ -33,10 +33,54 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ..\npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: ${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -82,11 +126,17 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: ${{ matrix.node-version }}
+          check-latest: contains(matrix.node-version, '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
       - name: Update Windows npm
-        # node 12 and 14 ship with npm@6, which is known to fail when updating itself in windows
-        if: matrix.platform.os == 'windows-latest' && (startsWith(matrix.node-version, '12.') || startsWith(matrix.node-version, '14.'))
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
         run: |
           curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
           tar xf npm-7.5.4.tgz
@@ -94,12 +144,36 @@ jobs:
           node lib/npm.js install --no-fund --no-audit -g ..\npm-7.5.4.tgz
           cd ..
           rmdir /s /q package
-      - name: Install npm@7
-        if: startsWith(matrix.node-version, '10.')
-        run: npm i --prefer-online --no-fund --no-audit -g npm@7
-      - name: Install npm@latest
-        if: ${{ !startsWith(matrix.node-version, '10.') }}
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: ${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,54 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ..\npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: ${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -82,11 +126,17 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: ${{ matrix.node-version }}
+          check-latest: contains(matrix.node-version, '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
       - name: Update Windows npm
-        # node 12 and 14 ship with npm@6, which is known to fail when updating itself in windows
-        if: matrix.platform.os == 'windows-latest' && (startsWith(matrix.node-version, '12.') || startsWith(matrix.node-version, '14.'))
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
         run: |
           curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
           tar xf npm-7.5.4.tgz
@@ -94,12 +144,36 @@ jobs:
           node lib/npm.js install --no-fund --no-audit -g ..\npm-7.5.4.tgz
           cd ..
           rmdir /s /q package
-      - name: Install npm@7
-        if: startsWith(matrix.node-version, '10.')
-        run: npm i --prefer-online --no-fund --no-audit -g npm@7
-      - name: Install npm@latest
-        if: ${{ !startsWith(matrix.node-version, '10.') }}
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: ${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies

--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -26,10 +26,54 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ..\npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: ${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -29,10 +29,54 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ..\npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: ${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,10 +42,54 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ..\npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: ${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -155,10 +199,54 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ..\npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: ${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies

--- a/lib/content/_step-node.yml
+++ b/lib/content/_step-node.yml
@@ -1,15 +1,20 @@
 - name: Setup Node
   uses: actions/setup-node@v3
+  id: node
   with:
     node-version: {{#if jobIsMatrix}}$\{{ matrix.node-version }}{{else}}{{ last ciVersions }}{{/if}}
+    check-latest: contains({{#if jobIsMatrix}}matrix.node-version{{else}}'{{ last ciVersions }}'{{/if}}, '.x')
     {{#if lockfile}}
     cache: npm
     {{/if}}
+
 {{#if updateNpm}}
-{{#if jobIsMatrix}}
+# node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
 - name: Update Windows npm
-  # node 12 and 14 ship with npm@6, which is known to fail when updating itself in windows
-  if: matrix.platform.os == 'windows-latest' && (startsWith(matrix.node-version, '12.') || startsWith(matrix.node-version, '14.'))
+  if: |
+    matrix.platform.os == 'windows-latest' && (
+      startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+    )
   run: |
     curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
     tar xf npm-7.5.4.tgz
@@ -17,15 +22,36 @@
     node lib/npm.js install --no-fund --no-audit -g ..\npm-7.5.4.tgz
     cd ..
     rmdir /s /q package
-- name: Install npm@7
-  if: startsWith(matrix.node-version, '10.')
-  run: npm i --prefer-online --no-fund --no-audit -g npm@7
-- name: Install npm@{{ npmSpec }}
-  if: $\{{ !startsWith(matrix.node-version, '10.') }}
-{{else}}
-- name: Install npm@{{ npmSpec }}
-{{/if}}
-  run: npm i --prefer-online --no-fund --no-audit -g npm@{{ npmSpec }}
+
+# Start on Node 10 because we dont test on anything lower
+- name: Install npm@7 on Node 10
+  shell: bash
+  if: startsWith(steps.node.outputs.node-version, 'v10.')
+  id: npm-7
+  run: |
+    npm i --prefer-online --no-fund --no-audit -g npm@7
+    echo "updated=true" >> "$GITHUB_OUTPUT"
+
+- name: Install npm@8 on Node 12
+  shell: bash
+  if: startsWith(steps.node.outputs.node-version, 'v12.')
+  id: npm-8
+  run: |
+    npm i --prefer-online --no-fund --no-audit -g npm@8
+    echo "updated=true" >> "$GITHUB_OUTPUT"
+
+- name: Install npm@9 on Node 14/16/18.0
+  shell: bash
+  if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+  id: npm-9
+  run: |
+    npm i --prefer-online --no-fund --no-audit -g npm@9
+    echo "updated=true" >> "$GITHUB_OUTPUT"
+
+- name: Install npm@latest on Node
+  if: $\{{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
+  run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
 - name: npm Version
   run: npm -v
 {{/if}}

--- a/lib/content/index.js
+++ b/lib/content/index.js
@@ -163,7 +163,6 @@ module.exports = {
   publish: false,
   npm: 'npm',
   npx: 'npx',
-  npmSpec: 'latest',
   updateNpm: true,
   dependabot: 'increase-if-necessary',
   unwantedPackages: [

--- a/tap-snapshots/test/apply/source-snapshots.js.test.cjs
+++ b/tap-snapshots/test/apply/source-snapshots.js.test.cjs
@@ -250,10 +250,54 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -347,10 +391,54 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -448,11 +536,17 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: \${{ matrix.node-version }}
+          check-latest: contains(matrix.node-version, '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
       - name: Update Windows npm
-        # node 12 and 14 ship with npm@6, which is known to fail when updating itself in windows
-        if: matrix.platform.os == 'windows-latest' && (startsWith(matrix.node-version, '12.') || startsWith(matrix.node-version, '14.'))
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
         run: |
           curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
           tar xf npm-7.5.4.tgz
@@ -460,12 +554,36 @@ jobs:
           node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
           cd ..
           rmdir /s /q package
-      - name: Install npm@7
-        if: startsWith(matrix.node-version, '10.')
-        run: npm i --prefer-online --no-fund --no-audit -g npm@7
-      - name: Install npm@latest
-        if: \${{ !startsWith(matrix.node-version, '10.') }}
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -517,10 +635,54 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -566,11 +728,17 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: \${{ matrix.node-version }}
+          check-latest: contains(matrix.node-version, '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
       - name: Update Windows npm
-        # node 12 and 14 ship with npm@6, which is known to fail when updating itself in windows
-        if: matrix.platform.os == 'windows-latest' && (startsWith(matrix.node-version, '12.') || startsWith(matrix.node-version, '14.'))
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
         run: |
           curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
           tar xf npm-7.5.4.tgz
@@ -578,12 +746,36 @@ jobs:
           node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
           cd ..
           rmdir /s /q package
-      - name: Install npm@7
-        if: startsWith(matrix.node-version, '10.')
-        run: npm i --prefer-online --no-fund --no-audit -g npm@7
-      - name: Install npm@latest
-        if: \${{ !startsWith(matrix.node-version, '10.') }}
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -666,10 +858,54 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -793,10 +1029,54 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -861,10 +1141,54 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -974,10 +1298,54 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -1140,10 +1508,54 @@ jobs:
     steps:
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: View in Registry
@@ -1694,10 +2106,54 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -1746,10 +2202,54 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -1795,11 +2295,17 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: \${{ matrix.node-version }}
+          check-latest: contains(matrix.node-version, '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
       - name: Update Windows npm
-        # node 12 and 14 ship with npm@6, which is known to fail when updating itself in windows
-        if: matrix.platform.os == 'windows-latest' && (startsWith(matrix.node-version, '12.') || startsWith(matrix.node-version, '14.'))
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
         run: |
           curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
           tar xf npm-7.5.4.tgz
@@ -1807,12 +2313,36 @@ jobs:
           node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
           cd ..
           rmdir /s /q package
-      - name: Install npm@7
-        if: startsWith(matrix.node-version, '10.')
-        run: npm i --prefer-online --no-fund --no-audit -g npm@7
-      - name: Install npm@latest
-        if: \${{ !startsWith(matrix.node-version, '10.') }}
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -1861,10 +2391,54 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -1910,11 +2484,17 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: \${{ matrix.node-version }}
+          check-latest: contains(matrix.node-version, '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
       - name: Update Windows npm
-        # node 12 and 14 ship with npm@6, which is known to fail when updating itself in windows
-        if: matrix.platform.os == 'windows-latest' && (startsWith(matrix.node-version, '12.') || startsWith(matrix.node-version, '14.'))
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
         run: |
           curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
           tar xf npm-7.5.4.tgz
@@ -1922,12 +2502,36 @@ jobs:
           node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
           cd ..
           rmdir /s /q package
-      - name: Install npm@7
-        if: startsWith(matrix.node-version, '10.')
-        run: npm i --prefer-online --no-fund --no-audit -g npm@7
-      - name: Install npm@latest
-        if: \${{ !startsWith(matrix.node-version, '10.') }}
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -2021,10 +2625,54 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -2122,11 +2770,17 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: \${{ matrix.node-version }}
+          check-latest: contains(matrix.node-version, '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
       - name: Update Windows npm
-        # node 12 and 14 ship with npm@6, which is known to fail when updating itself in windows
-        if: matrix.platform.os == 'windows-latest' && (startsWith(matrix.node-version, '12.') || startsWith(matrix.node-version, '14.'))
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
         run: |
           curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
           tar xf npm-7.5.4.tgz
@@ -2134,12 +2788,36 @@ jobs:
           node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
           cd ..
           rmdir /s /q package
-      - name: Install npm@7
-        if: startsWith(matrix.node-version, '10.')
-        run: npm i --prefer-online --no-fund --no-audit -g npm@7
-      - name: Install npm@latest
-        if: \${{ !startsWith(matrix.node-version, '10.') }}
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -2197,10 +2875,54 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -2246,11 +2968,17 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: \${{ matrix.node-version }}
+          check-latest: contains(matrix.node-version, '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
       - name: Update Windows npm
-        # node 12 and 14 ship with npm@6, which is known to fail when updating itself in windows
-        if: matrix.platform.os == 'windows-latest' && (startsWith(matrix.node-version, '12.') || startsWith(matrix.node-version, '14.'))
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
         run: |
           curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
           tar xf npm-7.5.4.tgz
@@ -2258,12 +2986,36 @@ jobs:
           node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
           cd ..
           rmdir /s /q package
-      - name: Install npm@7
-        if: startsWith(matrix.node-version, '10.')
-        run: npm i --prefer-online --no-fund --no-audit -g npm@7
-      - name: Install npm@latest
-        if: \${{ !startsWith(matrix.node-version, '10.') }}
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -2346,10 +3098,54 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -2473,10 +3269,54 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -2541,10 +3381,54 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -2654,10 +3538,54 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -2820,10 +3748,54 @@ jobs:
     steps:
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: View in Registry
@@ -3438,10 +4410,54 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -3487,11 +4503,17 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: \${{ matrix.node-version }}
+          check-latest: contains(matrix.node-version, '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
       - name: Update Windows npm
-        # node 12 and 14 ship with npm@6, which is known to fail when updating itself in windows
-        if: matrix.platform.os == 'windows-latest' && (startsWith(matrix.node-version, '12.') || startsWith(matrix.node-version, '14.'))
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
         run: |
           curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
           tar xf npm-7.5.4.tgz
@@ -3499,12 +4521,36 @@ jobs:
           node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
           cd ..
           rmdir /s /q package
-      - name: Install npm@7
-        if: startsWith(matrix.node-version, '10.')
-        run: npm i --prefer-online --no-fund --no-audit -g npm@7
-      - name: Install npm@latest
-        if: \${{ !startsWith(matrix.node-version, '10.') }}
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -3553,10 +4599,54 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -3602,11 +4692,17 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: \${{ matrix.node-version }}
+          check-latest: contains(matrix.node-version, '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
       - name: Update Windows npm
-        # node 12 and 14 ship with npm@6, which is known to fail when updating itself in windows
-        if: matrix.platform.os == 'windows-latest' && (startsWith(matrix.node-version, '12.') || startsWith(matrix.node-version, '14.'))
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
         run: |
           curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
           tar xf npm-7.5.4.tgz
@@ -3614,12 +4710,36 @@ jobs:
           node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
           cd ..
           rmdir /s /q package
-      - name: Install npm@7
-        if: startsWith(matrix.node-version, '10.')
-        run: npm i --prefer-online --no-fund --no-audit -g npm@7
-      - name: Install npm@latest
-        if: \${{ !startsWith(matrix.node-version, '10.') }}
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -3713,10 +4833,54 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -3814,11 +4978,17 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: \${{ matrix.node-version }}
+          check-latest: contains(matrix.node-version, '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
       - name: Update Windows npm
-        # node 12 and 14 ship with npm@6, which is known to fail when updating itself in windows
-        if: matrix.platform.os == 'windows-latest' && (startsWith(matrix.node-version, '12.') || startsWith(matrix.node-version, '14.'))
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
         run: |
           curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
           tar xf npm-7.5.4.tgz
@@ -3826,12 +4996,36 @@ jobs:
           node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
           cd ..
           rmdir /s /q package
-      - name: Install npm@7
-        if: startsWith(matrix.node-version, '10.')
-        run: npm i --prefer-online --no-fund --no-audit -g npm@7
-      - name: Install npm@latest
-        if: \${{ !startsWith(matrix.node-version, '10.') }}
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -3878,10 +5072,54 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -4005,10 +5243,54 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -4073,10 +5355,54 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -4186,10 +5512,54 @@ jobs:
           git config --global user.name "npm CLI robot"
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: Install Dependencies
@@ -4352,10 +5722,54 @@ jobs:
     steps:
       - name: Setup Node
         uses: actions/setup-node@v3
+        id: node
         with:
           node-version: 18.x
-      - name: Install npm@latest
+          check-latest: contains('18.x', '.x')
+
+      # node 10/12/14 ship with npm@6, which is known to fail when updating itself in windows
+      - name: Update Windows npm
+        if: |
+          matrix.platform.os == 'windows-latest' && (
+            startsWith(steps.node.outputs.node-version, 'v10.') || startsWith(steps.node.outputs.node-version, 'v12.') || startsWith(steps.node.outputs.node-version, 'v14.')
+          )
+        run: |
+          curl -sO https://registry.npmjs.org/npm/-/npm-7.5.4.tgz
+          tar xf npm-7.5.4.tgz
+          cd package
+          node lib/npm.js install --no-fund --no-audit -g ../npm-7.5.4.tgz
+          cd ..
+          rmdir /s /q package
+
+      # Start on Node 10 because we dont test on anything lower
+      - name: Install npm@7 on Node 10
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v10.')
+        id: npm-7
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@7
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@8 on Node 12
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v12.')
+        id: npm-8
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@8
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@9 on Node 14/16/18.0
+        shell: bash
+        if: startsWith(steps.node.outputs.node-version, 'v14.') || startsWith(steps.node.outputs.node-version, 'v16.') || startsWith(steps.node.outputs.node-version, 'v18.0.')
+        id: npm-9
+        run: |
+          npm i --prefer-online --no-fund --no-audit -g npm@9
+          echo "updated=true" >> "$GITHUB_OUTPUT"
+
+      - name: Install npm@latest on Node
+        if: \${{ !(steps.npm-7.outputs.updated || steps.npm-8.outputs.updated || steps.npm-9.outputs.updated) }}
         run: npm i --prefer-online --no-fund --no-audit -g npm@latest
+
       - name: npm Version
         run: npm -v
       - name: View in Registry


### PR DESCRIPTION
Fixes #353

This removes the `npmSpec` config in favor of installing an npm major based on the node version.

This will help us get more CI running npm@10 for older packages that only support npm@10 in some CI versions.
