### PR TITLE
fix: allow overriding path to npm bin in workspaces

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -23,19 +23,36 @@ const deglob = (v) => makePosix(v).replace(/[/*]+$/, '')
 const posixDir = (v) => `${v === '.' ? '' : deglob(v).replace(/\/$/, '')}${posix.sep}`
 const posixGlob = (str) => `${posixDir(str)}**`
 
-const getCmdPath = (key, { rootConfig, defaultConfig, isRoot, pkg, rootPkg }) => {
-  // Make a path relative from a workspace to the root if we are in a workspace
-  const wsToRoot = (p) => isRoot ? p : makePosix(join(relative(pkg.path, rootPkg.path), p))
+const getCmdPath = (key, { pkgConfig, rootConfig, isRoot, pkg, rootPkg }) => {
+  const result = (local, isRelative) => {
+    let root = local
+    const isLocal = local.startsWith('.') || local.startsWith('/')
 
-  const rootPath = rootConfig[key]
-  const defaultPath = defaultConfig[key]
-  const isLocal = rootPath && rootPath !== defaultPath
+    if (isLocal) {
+      if (isRelative) {
+        // Make a path relative from a workspace to the root if we are in a workspace
+        local = makePosix(join(relative(pkg.path, rootPkg.path), local))
+      }
+      local = `node ${local}`
+      root = `node ${root}`
+    }
 
-  return {
-    isLocal,
-    root: !isLocal ? defaultPath : `node ${rootPath}`,
-    local: !isLocal ? defaultPath : `node ${wsToRoot(rootPath)}`,
+    return {
+      isLocal,
+      local,
+      root,
+    }
   }
+
+  if (pkgConfig[key]) {
+    return result(pkgConfig[key])
+  }
+
+  if (rootConfig[key]) {
+    return result(rootConfig[key], !isRoot)
+  }
+
+  return result(key)
 }
 
 const mergeConfigs = (...configs) => {
@@ -139,9 +156,8 @@ const getFullConfig = async ({
     ] : [],
   ]
 
-  // root only configs
-  const npmPath = getCmdPath('npm', { rootConfig, defaultConfig, isRoot, pkg, rootPkg })
-  const npxPath = getCmdPath('npx', { rootConfig, defaultConfig, isRoot, pkg, rootPkg })
+  const npmPath = getCmdPath('npm', { pkgConfig, rootConfig, isRoot, pkg, rootPkg })
+  const npxPath = getCmdPath('npx', { pkgConfig, rootConfig, isRoot, pkg, rootPkg })
 
   // these are written to ci yml files so it needs to always use posix
   const pkgPath = makePosix(relative(rootPkg.path, pkg.path)) || '.'

--- a/lib/content/index.js
+++ b/lib/content/index.js
@@ -161,8 +161,6 @@ module.exports = {
   codeowner: '@npm/cli-team',
   eslint: true,
   publish: false,
-  npm: 'npm',
-  npx: 'npx',
   updateNpm: true,
   dependabot: 'increase-if-necessary',
   unwantedPackages: [


### PR DESCRIPTION
This will fix the issue in npm/cli where we want to run older npm versions for some workspaces.