### PR TITLE
docs: add note about semver and breaking changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,11 @@
 This module bundles the npm CLI team's basics for package development into a
 single devDependency.
 
-**CAUTION: THESE CHANGES WILL OVERWRITE LOCAL FILES AND SETTINGS**
+> [!WARNING]  
+> THESE CHANGES WILL OVERWRITE LOCAL FILES AND SETTINGS
+
+> [!IMPORTANT]  
+> This package does not follow semantic versioning for its API. This package is designed to be installed with `--save-exact` and therefore will make breaking API changes outside of major versions, including `engines` narrowing. Major versions are reserved for breaking changes to files written to a repo by this package.
 
 ### Configuration
 


### PR DESCRIPTION
This has always been true for this package, but we haven't made too many API breaking changes. Recently #362 landed which is a breaking change, since the API includes shadowing and using these files as partials. So it is best to embrace these types of changes and document the behavior.