### PR TITLE
fix: give release integration workflow correct permissions and secrets

### DIFF
--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -15,6 +15,9 @@ on:
         required: true
         type: string
         description: 'A json array of releases. Required fields: publish: tagName, publishTag. publish check: pkgName, version'
+    secrets:
+      PUBLISH_TOKEN:
+        required: true
 
 jobs:
   publish:
@@ -24,7 +27,6 @@ jobs:
       run:
         shell: bash
     permissions:
-      deployments: write
       id-token: write
     steps:
       - name: Checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,6 +243,10 @@ jobs:
     name: Release Integration
     if: needs.release.outputs.releases
     uses: ./.github/workflows/release-integration.yml
+    permissions:
+      id-token: write
+    secrets:
+      PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
     with:
       releases: ${{ needs.release.outputs.releases }}
 

--- a/lib/content/_job-release-integration-yml.hbs
+++ b/lib/content/_job-release-integration-yml.hbs
@@ -5,7 +5,6 @@ defaults:
     shell: bash
 {{#if publish}}
 permissions:
-  deployments: write
   id-token: write
 {{/if}}
 steps:

--- a/lib/content/release-integration-yml.hbs
+++ b/lib/content/release-integration-yml.hbs
@@ -13,6 +13,11 @@ on:
         required: true
         type: string
         description: 'A json array of releases. Required fields: publish: tagName, publishTag. publish check: pkgName, version'
+    {{#if publish}}
+    secrets:
+      PUBLISH_TOKEN:
+        required: true
+    {{/if}} 
 
 jobs:
   publish:

--- a/lib/content/release-yml.hbs
+++ b/lib/content/release-yml.hbs
@@ -184,6 +184,12 @@ jobs:
     name: Release Integration
     if: needs.release.outputs.releases
     uses: ./.github/workflows/release-integration.yml
+    {{#if publish}}
+    permissions:
+      id-token: write
+    secrets:
+      PUBLISH_TOKEN: $\{{ secrets.PUBLISH_TOKEN }}
+    {{/if}}
     with:
       releases: $\{{ needs.release.outputs.releases }}
 


### PR DESCRIPTION
Since it is now invoked by `workflow_call` the permissions need to be set by both the caller and callee.

This also only forwards the necessary PUBLISH_TOKEN secret to the workflow instead of all secrets.

The above two things are only applied when `publish: true` is set.