### PR TITLE
fix: fallback to default release process of 404 from hosted version

### DIFF
--- a/lib/release/release-manager.js
+++ b/lib/release/release-manager.js
@@ -62,10 +62,8 @@ class ReleaseManager {
     const [release, workspaces = []] = await this.#getPrReleases({ pullRequest })
     const releaseItems = await this.#getReleaseProcess({ release, workspaces })
 
-    core.info(
-    `Filtered ${releaseItems.length} release process items:\n`,
-    releaseItems.map(r => r.split('\n')[0].replace('- [ ] ', '')).join(', ')
-    )
+    core.info(`Filtered ${releaseItems.length} release process items:`)
+    core.info(releaseItems.map(r => r.split('\n')[0].replace('- [ ] ', '')).join(', '))
 
     const checklist = releaseItems
       .join('\n\n')
@@ -125,7 +123,7 @@ class ReleaseManager {
         throw new Error('Could not find version with:', ROOT_VERSION)
       }
 
-      core.info('Found version', version)
+      core.info(`Found version: ${version}`)
       return [getReleaseInfo({ version })]
     }
 
@@ -136,10 +134,10 @@ class ReleaseManager {
       const release = getReleaseInfo({ name, version })
 
       if (!name) {
-        core.info('Found root', release)
+        core.info(`Found root: ${JSON.stringify(release)}`)
         acc[0] = release
       } else {
-        core.info('Found workspace', release)
+        core.info(`Found workspace: ${JSON.stringify(release)}`)
         acc[1].push(release)
       }
 
@@ -150,13 +148,22 @@ class ReleaseManager {
   async #getReleaseProcess ({ release, workspaces }) {
     const RELEASE_LIST_ITEM = /^\d+\.\s/gm
 
-    core.info(`Fetching release process from:`, this.#owner, this.#repo, 'wiki')
+    core.info(`Fetching release process from repo wiki: ${this.#owner}/${this.#repo}`)
 
     const releaseProcess = await fetch(
       `https://raw.githubusercontent.com/wiki/${this.#owner}/${this.#repo}/Release-Process.md`
     )
-      .then(r => r.text())
-      .catch(() => this.#getReleaseSteps())
+      .then(r => {
+        if (r.status === 200) {
+          core.info('Found release process from wiki')
+          return r.text()
+        } else if (r.status === 404) {
+          core.info('No release process found in wiki, falling back to default process')
+          return this.#getReleaseSteps()
+        } else {
+          throw new Error(`Release process fetch failed with status: ${r.status}`)
+        }
+      })
 
     // XXX: the release steps need to always be the last thing in the doc for this to work
     const releaseLines = releaseProcess.split('\n')


### PR DESCRIPTION
This also fixes the release manager logging since `core.info` only allows a single string argument.

These changes are not tested because they are all tested in #334. But I wanted to fix this bug before that gets reviewed.