### PR TITLE
fix: iterate over releases from env var

### DIFF
--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Publish
         env:
           PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
+          RELEASES: ${{ inputs.releases }}
         run: |
           EXIT_CODE=0
 
@@ -65,7 +66,7 @@ jobs:
             fi
           }
 
-          for release in $(echo '${{ inputs.releases }}' | jq -r '.[] | @base64'); do
+          for release in $(echo $RELEASES | jq -r '.[] | @base64'); do
             PUBLISH_TAG=$(echo "$release" | base64 --decode | jq -r .publishTag)
             STATUS=$(each_release "$PUBLISH_TAG")
             if [[ "$STATUS" -eq 1 ]]; then

--- a/lib/content/_job-release-integration-yml.hbs
+++ b/lib/content/_job-release-integration-yml.hbs
@@ -15,6 +15,7 @@ steps:
   - name: Publish
     env:
       PUBLISH_TOKEN: $\{{ secrets.PUBLISH_TOKEN }}
+      RELEASES: $\{{ inputs.releases }}
   {{else}}
   {{> stepsSetupYml }}
   - name: Check If Published
@@ -30,7 +31,7 @@ steps:
         fi
       }
 
-      for release in $(echo '$\{{ inputs.releases }}' | jq -r '.[] | @base64'); do
+      for release in $(echo $RELEASES | jq -r '.[] | @base64'); do
         {{#if publish}}
         PUBLISH_TAG=$(echo "$release" | base64 --decode | jq -r .publishTag)
         STATUS=$(each_release "$PUBLISH_TAG")

--- a/tap-snapshots/test/apply/source-snapshots.js.test.cjs
+++ b/tap-snapshots/test/apply/source-snapshots.js.test.cjs
@@ -896,7 +896,7 @@ jobs:
             fi
           }
 
-          for release in $(echo '\${{ inputs.releases }}' | jq -r '.[] | @base64'); do
+          for release in $(echo $RELEASES | jq -r '.[] | @base64'); do
             SPEC="$(echo "$release" | base64 --decode | jq -r .pkgName)@$(echo "$release" | base64 --decode | jq -r .version)"
             STATUS=$(each_release "$SPEC")
             if [[ "$STATUS" -eq 1 ]]; then
@@ -2537,7 +2537,7 @@ jobs:
             fi
           }
 
-          for release in $(echo '\${{ inputs.releases }}' | jq -r '.[] | @base64'); do
+          for release in $(echo $RELEASES | jq -r '.[] | @base64'); do
             SPEC="$(echo "$release" | base64 --decode | jq -r .pkgName)@$(echo "$release" | base64 --decode | jq -r .version)"
             STATUS=$(each_release "$SPEC")
             if [[ "$STATUS" -eq 1 ]]; then
@@ -4051,7 +4051,7 @@ jobs:
             fi
           }
 
-          for release in $(echo '\${{ inputs.releases }}' | jq -r '.[] | @base64'); do
+          for release in $(echo $RELEASES | jq -r '.[] | @base64'); do
             SPEC="$(echo "$release" | base64 --decode | jq -r .pkgName)@$(echo "$release" | base64 --decode | jq -r .version)"
             STATUS=$(each_release "$SPEC")
             if [[ "$STATUS" -eq 1 ]]; then


### PR DESCRIPTION
This fixes an issue where single quotes within releases were not escaped.

Copied directly from https://github.com/npm/proc-log/pull/79