### PR TITLE
fix: only use latest template-oss specific commits in changelog

### DIFF
--- a/lib/release/changelog.js
+++ b/lib/release/changelog.js
@@ -110,7 +110,7 @@ class ChangelogNotes {
     return authorsByCommit
   }
 
-  async #getPullRequestForCommits (commits) {
+  async #getPullRequestNumbersForCommits (commits) {
     const shas = commits
       .filter(c => !c.pullRequest?.number)
       .map(c => c.sha)
@@ -134,7 +134,7 @@ class ChangelogNotes {
     return pullRequestsByCommit
   }
 
-  #buildEntry (commit, { authors = [], pullRequest }) {
+  #buildEntry (commit) {
     const entry = []
 
     if (commit.sha) {
@@ -143,7 +143,7 @@ class ChangelogNotes {
     }
 
     // A link to the pull request if the commit has one
-    const commitPullRequest = commit.pullRequest?.number ?? pullRequest
+    const commitPullRequest = commit.pullRequestNumber
     if (commitPullRequest) {
       entry.push(link(`#${commitPullRequest}`, this.#ghUrl('pull', commitPullRequest)))
     }
@@ -154,21 +154,65 @@ class ChangelogNotes {
     entry.push([scope, subject].filter(Boolean).join(' '))
 
     // A list og the authors github handles or names
-    if (authors.length) {
-      entry.push(`(${authors.join(', ')})`)
+    if (commit.authors.length) {
+      entry.push(`(${commit.authors.join(', ')})`)
     }
 
     return entry.join(' ')
   }
 
-  async buildNotes (commits, { version, previousTag, currentTag, changelogSections }) {
+  #filterCommits (commits) {
+    const filteredCommits = []
+    const keyedDuplicates = {}
+
+    // Filter certain commits so we can make sure only the latest version of
+    // each one gets into the changelog
+    for (const commit of commits) {
+      if (commit.bareMessage.startsWith('postinstall for dependabot template-oss PR')) {
+        keyedDuplicates.templateOssPostInstall ??= []
+        keyedDuplicates.templateOssPostInstall.push(commit)
+        continue
+      }
+
+      if (commit.bareMessage.startsWith('bump @npmcli/template-oss from')) {
+        keyedDuplicates.templateOssBump ??= []
+        keyedDuplicates.templateOssBump.push(commit)
+        continue
+      }
+
+      filteredCommits.push(commit)
+    }
+
+    // Sort all our duplicates so we get the latest verion (by PR number) of each type.
+    // Then flatten so we can put them all back into the changelog
+    const sortedDupes = Object.values(keyedDuplicates)
+      .filter((items) => Boolean(items.length))
+      .map((items) => items.sort((a, b) => b.pullRequestNumber - a.pullRequestNumber))
+      .flatMap(items => items[0])
+
+    // This moves them to the bottom of their changelog section which is not
+    // strictly necessary but it's easier to do this way.
+    for (const duplicate of sortedDupes) {
+      filteredCommits.push(duplicate)
+    }
+
+    return filteredCommits
+  }
+
+  async buildNotes (rawCommits, { version, previousTag, currentTag, changelogSections }) {
     // get authors for commits for each sha
-    const authorsByCommit = await this.#getAuthorsForCommits(commits)
+    const authors = await this.#getAuthorsForCommits(rawCommits)
 
     // when rebase merging multiple commits with a single PR, only the first commit
     // will have a pr number when coming from release-please. this check will manually
     // lookup commits without a pr number and find one if it exists
-    const pullRequestByCommit = await this.#getPullRequestForCommits(commits)
+    const prNumbers = await this.#getPullRequestNumbersForCommits(rawCommits)
+
+    const fullCommits = rawCommits.map((commit) => {
+      commit.authors = authors[commit.sha] ?? []
+      commit.pullRequestNumber = Number(commit.pullRequest?.number ?? prNumbers[commit.sha])
+      return commit
+    })
 
     const changelog = new Changelog({
       version,
@@ -178,12 +222,9 @@ class ChangelogNotes {
       sections: changelogSections,
     })
 
-    for (const commit of commits) {
+    for (const commit of this.#filterCommits(fullCommits)) {
       // Collect commits by type
-      changelog.add(commit.type, this.#buildEntry(commit, {
-        authors: authorsByCommit[commit.sha],
-        pullRequest: pullRequestByCommit[commit.sha],
-      }))
+      changelog.add(commit.type, this.#buildEntry(commit))
 
       // And breaking changes to its own section
       changelog.add(Changelog.BREAKING, ...commit.notes


### PR DESCRIPTION
This is tested with mocked commits within `template-oss` because it's still hard to test this  kind of stuff intergration style with `release-please`.

I did manually run this code against https://github.com/npm/npm-cli-release-please and for two PRs with the `postinstall for dependabot template-oss` commit message, only one made it to the changelog. https://github.com/npm/npm-cli-release-please/pull/246

Screenshots since any links to that repo might change due to other tests. Note that only PR `#274` is in the changelog and not `#273`.

<img width="886" alt="Screenshot 2024-04-15 at 12 15 00 PM" src="https://github.com/npm/template-oss/assets/542108/83cfbae5-d7ce-4eb8-bf0e-8972e83adf01">
<img width="628" alt="Screenshot 2024-04-15 at 12 15 10 PM" src="https://github.com/npm/template-oss/assets/542108/0cb4c0ad-92bc-407e-8197-710ab336b14a">
