### PR TITLE
fix: dont create chore only PRs

### DIFF
--- a/lib/content/index.js
+++ b/lib/content/index.js
@@ -199,10 +199,10 @@ module.exports = {
   },
   allowedPackages: [],
   changelogTypes: [
-    { type: 'feat', section: 'Features', hidden: false, collapse: false },
-    { type: 'fix', section: 'Bug Fixes', hidden: false, collapse: false },
-    { type: 'docs', section: 'Documentation', hidden: false, collapse: false },
-    { type: 'deps', section: 'Dependencies', hidden: false, collapse: false },
-    { type: 'chore', section: 'Chores', hidden: false, collapse: false },
+    { type: 'feat', section: 'Features', hidden: false },
+    { type: 'fix', section: 'Bug Fixes', hidden: false },
+    { type: 'docs', section: 'Documentation', hidden: false },
+    { type: 'deps', section: 'Dependencies', hidden: false },
+    { type: 'chore', section: 'Chores', hidden: true },
   ],
 }

--- a/lib/release/changelog.js
+++ b/lib/release/changelog.js
@@ -29,28 +29,28 @@ class Changelog {
   }
 
   #getEntries (type) {
-    const section = this.#sections[type]
-    const entries = this.#entries[type].map(list)
-    // Ignoring coverage until we use this again
-    /* istanbul ignore next */
-    if (section?.collapse) {
-      entries.unshift('<details><summary>Commits</summary>\n')
-      entries.push('\n</details>')
-    }
-    return entries.join('\n')
+    return this.#entries[type].map(list).join('\n')
   }
 
   toString () {
     const body = [this.#title]
+    const includedTypes = []
+
     for (const type of this.#types) {
-      const title = this.#titles[type]
       if (this.#entries[type]?.length) {
-        body.push(
-          `### ${title}`,
-          this.#getEntries(type)
-        )
+        includedTypes.push(type)
+        body.push(`### ${this.#titles[type]}`, this.#getEntries(type))
       }
     }
+
+    // If every commit is from a hidden section then we return an
+    // empty string which will skip the release PR being created.
+    // We do this because we don't want PRs opened if they only contain
+    // chores but we do want to rebuild existing PRs if chores are added.
+    if (includedTypes.every((type) => this.#sections[type]?.hidden)) {
+      return ''
+    }
+
     return body.join('\n\n').trim()
   }
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,32 +3,27 @@
     {
       "type": "feat",
       "section": "Features",
-      "hidden": false,
-      "collapse": false
+      "hidden": false
     },
     {
       "type": "fix",
       "section": "Bug Fixes",
-      "hidden": false,
-      "collapse": false
+      "hidden": false
     },
     {
       "type": "docs",
       "section": "Documentation",
-      "hidden": false,
-      "collapse": false
+      "hidden": false
     },
     {
       "type": "deps",
       "section": "Dependencies",
-      "hidden": false,
-      "collapse": false
+      "hidden": false
     },
     {
       "type": "chore",
       "section": "Chores",
-      "hidden": false,
-      "collapse": false
+      "hidden": true
     }
   ],
   "packages": {

--- a/tap-snapshots/test/apply/source-snapshots.js.test.cjs
+++ b/tap-snapshots/test/apply/source-snapshots.js.test.cjs
@@ -1368,32 +1368,27 @@ release-please-config.json
     {
       "type": "feat",
       "section": "Features",
-      "hidden": false,
-      "collapse": false
+      "hidden": false
     },
     {
       "type": "fix",
       "section": "Bug Fixes",
-      "hidden": false,
-      "collapse": false
+      "hidden": false
     },
     {
       "type": "docs",
       "section": "Documentation",
-      "hidden": false,
-      "collapse": false
+      "hidden": false
     },
     {
       "type": "deps",
       "section": "Dependencies",
-      "hidden": false,
-      "collapse": false
+      "hidden": false
     },
     {
       "type": "chore",
       "section": "Chores",
-      "hidden": false,
-      "collapse": false
+      "hidden": true
     }
   ],
   "prerelease-type": "pre",
@@ -3031,32 +3026,27 @@ release-please-config.json
     {
       "type": "feat",
       "section": "Features",
-      "hidden": false,
-      "collapse": false
+      "hidden": false
     },
     {
       "type": "fix",
       "section": "Bug Fixes",
-      "hidden": false,
-      "collapse": false
+      "hidden": false
     },
     {
       "type": "docs",
       "section": "Documentation",
-      "hidden": false,
-      "collapse": false
+      "hidden": false
     },
     {
       "type": "deps",
       "section": "Dependencies",
-      "hidden": false,
-      "collapse": false
+      "hidden": false
     },
     {
       "type": "chore",
       "section": "Chores",
-      "hidden": false,
-      "collapse": false
+      "hidden": true
     }
   ],
   "prerelease-type": "pre",
@@ -4410,32 +4400,27 @@ release-please-config.json
     {
       "type": "feat",
       "section": "Features",
-      "hidden": false,
-      "collapse": false
+      "hidden": false
     },
     {
       "type": "fix",
       "section": "Bug Fixes",
-      "hidden": false,
-      "collapse": false
+      "hidden": false
     },
     {
       "type": "docs",
       "section": "Documentation",
-      "hidden": false,
-      "collapse": false
+      "hidden": false
     },
     {
       "type": "deps",
       "section": "Dependencies",
-      "hidden": false,
-      "collapse": false
+      "hidden": false
     },
     {
       "type": "chore",
       "section": "Chores",
-      "hidden": false,
-      "collapse": false
+      "hidden": true
     }
   ],
   "prerelease-type": "pre",

--- a/test/release/changelog.js
+++ b/test/release/changelog.js
@@ -121,6 +121,10 @@ t.test('filters out multiple template oss commits', async t => {
   const changelog = await mockChangelog({
     authors: false,
     commits: [{
+      sha: 'z',
+      type: 'fix',
+      bareMessage: 'just a fix',
+    }, {
       sha: 'a',
       type: 'chore',
       bareMessage: 'postinstall for dependabot template-oss PR',
@@ -152,10 +156,28 @@ t.test('filters out multiple template oss commits', async t => {
   })
   t.strictSame(changelog, [
     '## [1.0.0](https://github.com/npm/cli/compare/v0.1.0...v1.0.0) (DATE)',
+    '### Bug Fixes',
+    '* [`z`](https://github.com/npm/cli/commit/z) just a fix',
     '### Chores',
     // eslint-disable-next-line max-len
     '* [`b`](https://github.com/npm/cli/commit/b) [#101](https://github.com/npm/cli/pull/101) postinstall for dependabot template-oss PR',
     // eslint-disable-next-line max-len
     '* [`c`](https://github.com/npm/cli/commit/c) [#101](https://github.com/npm/cli/pull/101) bump @npmcli/template-oss from 1 to 2',
   ])
+})
+
+t.test('empty change log with only chore commits', async t => {
+  const changelog = await mockChangelog({
+    authors: false,
+    commits: [{
+      sha: 'a',
+      type: 'chore',
+      bareMessage: 'some chore',
+    }, {
+      sha: 'a',
+      type: 'chore',
+      bareMessage: 'another chore',
+    }],
+  })
+  t.strictSame(changelog, [])
 })


### PR DESCRIPTION
In #378 we decided to make template-oss rebuild PRs for chore commits to solve the problem of needing to manually recreate PRs after pushing a chore that affected the release process.

This was a good change but had the side effects of:
- Creating noise in the `Chores` sections of the changelog for repos that don't get released often but landed a lot of template-oss updates between releases. This was greatly reduced in #430
- Creating release PRs in repos that didn't need an actual release because it was only chore commits. This PR fixes this by only creating a PR if there is at least one non-chore commit. This will continue to work around the original problem of updating pending releases for new chore commits, but won't open PRs for chores only.

As a side effect of this I removed the code that was responsible for collapsing the chores section. The goal was to reduce noise in the changelog but was never turned on because it didn't work right. I think the above two items reduce noise enough that we don't need to collapse the chores section anymore.