### PR TITLE
feat: use macos-(latest|13) based on node version

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -80,6 +80,9 @@ jobs:
           - name: macOS
             os: macos-latest
             shell: bash
+          - name: macOS
+            os: macos-13
+            shell: bash
           - name: Windows
             os: windows-latest
             shell: cmd
@@ -89,6 +92,17 @@ jobs:
           - 20.5.0
           - 20.x
           - 22.x
+        exclude:
+          - platform: { name: macOS, os: macos-13, shell: bash }
+            node-version: 18.17.0
+          - platform: { name: macOS, os: macos-13, shell: bash }
+            node-version: 18.x
+          - platform: { name: macOS, os: macos-13, shell: bash }
+            node-version: 20.5.0
+          - platform: { name: macOS, os: macos-13, shell: bash }
+            node-version: 20.x
+          - platform: { name: macOS, os: macos-13, shell: bash }
+            node-version: 22.x
     runs-on: ${{ matrix.platform.os }}
     defaults:
       run:

--- a/.github/workflows/ci-test-workspace.yml
+++ b/.github/workflows/ci-test-workspace.yml
@@ -61,6 +61,9 @@ jobs:
           - name: macOS
             os: macos-latest
             shell: bash
+          - name: macOS
+            os: macos-13
+            shell: bash
           - name: Windows
             os: windows-latest
             shell: cmd
@@ -70,6 +73,17 @@ jobs:
           - 20.5.0
           - 20.x
           - 22.x
+        exclude:
+          - platform: { name: macOS, os: macos-13, shell: bash }
+            node-version: 18.17.0
+          - platform: { name: macOS, os: macos-13, shell: bash }
+            node-version: 18.x
+          - platform: { name: macOS, os: macos-13, shell: bash }
+            node-version: 20.5.0
+          - platform: { name: macOS, os: macos-13, shell: bash }
+            node-version: 20.x
+          - platform: { name: macOS, os: macos-13, shell: bash }
+            node-version: 22.x
     runs-on: ${{ matrix.platform.os }}
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,9 @@ jobs:
           - name: macOS
             os: macos-latest
             shell: bash
+          - name: macOS
+            os: macos-13
+            shell: bash
           - name: Windows
             os: windows-latest
             shell: cmd
@@ -70,6 +73,17 @@ jobs:
           - 20.5.0
           - 20.x
           - 22.x
+        exclude:
+          - platform: { name: macOS, os: macos-13, shell: bash }
+            node-version: 18.17.0
+          - platform: { name: macOS, os: macos-13, shell: bash }
+            node-version: 18.x
+          - platform: { name: macOS, os: macos-13, shell: bash }
+            node-version: 20.5.0
+          - platform: { name: macOS, os: macos-13, shell: bash }
+            node-version: 20.x
+          - platform: { name: macOS, os: macos-13, shell: bash }
+            node-version: 22.x
     runs-on: ${{ matrix.platform.os }}
     defaults:
       run:

--- a/lib/content/_job-matrix-yml.hbs
+++ b/lib/content/_job-matrix-yml.hbs
@@ -11,6 +11,9 @@ strategy:
       - name: macOS
         os: macos-latest
         shell: bash
+      - name: macOS
+        os: macos-13
+        shell: bash
       {{/if}}
       {{#if windowsCI}}
       - name: Windows
@@ -21,6 +24,13 @@ strategy:
       {{#each ciVersions}}
       - {{ . }}
       {{/each}}
+    {{#if macCI}}
+    exclude:
+      {{#each ciVersions}}
+      - platform: {name: macOS, os: macos-{{#if (lte (semverRangeMajor .) 14)}}latest{{else}}13{{/if}}, shell: bash}
+        node-version: {{ . }}
+      {{/each}}
+    {{/if}}
 runs-on: $\{{ matrix.platform.os }}
 defaults:
   run:

--- a/lib/util/template.js
+++ b/lib/util/template.js
@@ -1,5 +1,6 @@
 const Handlebars = require('handlebars')
 const { basename, extname, join } = require('path')
+const { Range } = require('semver')
 const fs = require('fs')
 const DELETE = '__DELETE__'
 
@@ -39,6 +40,8 @@ const setupHandlebars = (dirs) => {
   Handlebars.registerHelper('last', (arr) => arr[arr.length - 1])
   Handlebars.registerHelper('json', (c) => JSON.stringify(c))
   Handlebars.registerHelper('del', () => JSON.stringify(DELETE))
+  Handlebars.registerHelper('semverRangeMajor', (v) => new Range(v).set[0][0].semver.major)
+  Handlebars.registerHelper('lte', (a, b) => a <= b)
 
   if (Array.isArray(dirs)) {
     const [baseDir, ...otherDirs] = dirs

--- a/tap-snapshots/test/apply/source-snapshots.js.test.cjs
+++ b/tap-snapshots/test/apply/source-snapshots.js.test.cjs
@@ -471,11 +471,17 @@ jobs:
           - name: macOS
             os: macos-latest
             shell: bash
+          - name: macOS
+            os: macos-13
+            shell: bash
           - name: Windows
             os: windows-latest
             shell: cmd
         node-version:
           - 22.x
+        exclude:
+          - platform: { name: macOS, os: macos-13, shell: bash }
+            node-version: 22.x
     runs-on: \${{ matrix.platform.os }}
     defaults:
       run:
@@ -584,11 +590,17 @@ jobs:
           - name: macOS
             os: macos-latest
             shell: bash
+          - name: macOS
+            os: macos-13
+            shell: bash
           - name: Windows
             os: windows-latest
             shell: cmd
         node-version:
           - 22.x
+        exclude:
+          - platform: { name: macOS, os: macos-13, shell: bash }
+            node-version: 22.x
     runs-on: \${{ matrix.platform.os }}
     defaults:
       run:
@@ -1878,11 +1890,17 @@ jobs:
           - name: macOS
             os: macos-latest
             shell: bash
+          - name: macOS
+            os: macos-13
+            shell: bash
           - name: Windows
             os: windows-latest
             shell: cmd
         node-version:
           - 22.x
+        exclude:
+          - platform: { name: macOS, os: macos-13, shell: bash }
+            node-version: 22.x
     runs-on: \${{ matrix.platform.os }}
     defaults:
       run:
@@ -1978,11 +1996,17 @@ jobs:
           - name: macOS
             os: macos-latest
             shell: bash
+          - name: macOS
+            os: macos-13
+            shell: bash
           - name: Windows
             os: windows-latest
             shell: cmd
         node-version:
           - 22.x
+        exclude:
+          - platform: { name: macOS, os: macos-13, shell: bash }
+            node-version: 22.x
     runs-on: \${{ matrix.platform.os }}
     defaults:
       run:
@@ -2095,11 +2119,17 @@ jobs:
           - name: macOS
             os: macos-latest
             shell: bash
+          - name: macOS
+            os: macos-13
+            shell: bash
           - name: Windows
             os: windows-latest
             shell: cmd
         node-version:
           - 22.x
+        exclude:
+          - platform: { name: macOS, os: macos-13, shell: bash }
+            node-version: 22.x
     runs-on: \${{ matrix.platform.os }}
     defaults:
       run:
@@ -2214,11 +2244,17 @@ jobs:
           - name: macOS
             os: macos-latest
             shell: bash
+          - name: macOS
+            os: macos-13
+            shell: bash
           - name: Windows
             os: windows-latest
             shell: cmd
         node-version:
           - 22.x
+        exclude:
+          - platform: { name: macOS, os: macos-13, shell: bash }
+            node-version: 22.x
     runs-on: \${{ matrix.platform.os }}
     defaults:
       run:
@@ -3525,11 +3561,17 @@ jobs:
           - name: macOS
             os: macos-latest
             shell: bash
+          - name: macOS
+            os: macos-13
+            shell: bash
           - name: Windows
             os: windows-latest
             shell: cmd
         node-version:
           - 22.x
+        exclude:
+          - platform: { name: macOS, os: macos-13, shell: bash }
+            node-version: 22.x
     runs-on: \${{ matrix.platform.os }}
     defaults:
       run:
@@ -3625,11 +3667,17 @@ jobs:
           - name: macOS
             os: macos-latest
             shell: bash
+          - name: macOS
+            os: macos-13
+            shell: bash
           - name: Windows
             os: windows-latest
             shell: cmd
         node-version:
           - 22.x
+        exclude:
+          - platform: { name: macOS, os: macos-13, shell: bash }
+            node-version: 22.x
     runs-on: \${{ matrix.platform.os }}
     defaults:
       run:
@@ -3742,11 +3790,17 @@ jobs:
           - name: macOS
             os: macos-latest
             shell: bash
+          - name: macOS
+            os: macos-13
+            shell: bash
           - name: Windows
             os: windows-latest
             shell: cmd
         node-version:
           - 22.x
+        exclude:
+          - platform: { name: macOS, os: macos-13, shell: bash }
+            node-version: 22.x
     runs-on: \${{ matrix.platform.os }}
     defaults:
       run:

--- a/tap-snapshots/test/check/diff-snapshots.js.test.cjs
+++ b/tap-snapshots/test/check/diff-snapshots.js.test.cjs
@@ -175,7 +175,7 @@ The repo file ci.yml needs to be updated:
 
   .github/workflows/ci.yml
   ========================================
-  @@ -77,4 +77,24 @@
+  @@ -97,4 +97,24 @@
            shell: \${{ matrix.platform.shell }}
        steps:
          - name: Checkout


### PR DESCRIPTION
`macos-latest` recently switch to M1s which don't have Node builds for v14 and below. This change adds both macos-latest and macos-13 (which uses x86 cpus) and then excludes one or the other based on the Node version in the matrix. The result is still only one macOS CI job per Node version, but it will now use the correct CPU architecture per version. 