### PR TITLE
chore: bump @npmcli/template-oss to 4.22.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/npm/template-oss.git"
+    "url": "git+https://github.com/npm/template-oss.git"
   },
   "keywords": [
     "npm",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   ],
   "devDependencies": {
     "@npmcli/eslint-config": "^4.0.0",
-    "@npmcli/template-oss": "file:./",
+    "@npmcli/template-oss": "4.22.0",
     "nock": "^13.3.8",
     "tap": "^16.0.0"
   },

--- a/workspace/test-workspace/package.json
+++ b/workspace/test-workspace/package.json
@@ -20,7 +20,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/npm/template-oss.git",
+    "url": "git+https://github.com/npm/template-oss.git",
     "directory": "workspace/test-workspace"
   },
   "keywords": [],


### PR DESCRIPTION
- chore: bump @npmcli/template-oss to 4.22.0
- chore: postinstall for dependabot template-oss PR
