### PR TITLE
fix: pass releases to publish check

### DIFF
--- a/lib/content/_job-release-integration-yml.hbs
+++ b/lib/content/_job-release-integration-yml.hbs
@@ -19,6 +19,8 @@ steps:
   {{else}}
   {{> stepsSetupYml }}
   - name: Check If Published
+    env:
+      RELEASES: $\{{ inputs.releases }}
   {{/if}}
     run: |
       EXIT_CODE=0

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   ],
   "devDependencies": {
     "@npmcli/eslint-config": "^4.0.0",
-    "@npmcli/template-oss": "4.22.0",
+    "@npmcli/template-oss": "file:./",
     "nock": "^13.3.8",
     "tap": "^16.0.0"
   },

--- a/tap-snapshots/test/apply/source-snapshots.js.test.cjs
+++ b/tap-snapshots/test/apply/source-snapshots.js.test.cjs
@@ -898,6 +898,8 @@ jobs:
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Check If Published
+        env:
+          RELEASES: \${{ inputs.releases }}
         run: |
           EXIT_CODE=0
 
@@ -2552,6 +2554,8 @@ jobs:
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Check If Published
+        env:
+          RELEASES: \${{ inputs.releases }}
         run: |
           EXIT_CODE=0
 
@@ -4072,6 +4076,8 @@ jobs:
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Check If Published
+        env:
+          RELEASES: \${{ inputs.releases }}
         run: |
           EXIT_CODE=0
 


### PR DESCRIPTION
If `publish: true` is not set, then the release intergration workflow falls back to running `npm view $SPEC` which will error if the package has not been published. This tags the CODEOWNERS in the release issue so we know something went wrong.

This doesn't have much use now that we are moving everything to `publish: true` but it would have caught a missing publish last week that I missed on `@npmcli/fs`: https://github.com/npm/fs/actions/runs/8946801618/job/24577963034#step:7:4

The `RELEASES` env var was only being set for the publish step, not the check if published step.