### PR TITLE
fix: adds support for tap 19

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -169,7 +169,7 @@ const getFullConfig = async ({
     cjsExt: esm ? 'cjs' : 'js',
     deleteJsExt: esm ? 'js' : 'cjs',
     // tap
-    tap18: semver.coerce(pkg.pkgJson?.devDependencies?.tap)?.major === 18,
+    tapOver17: semver.coerce(pkg.pkgJson?.devDependencies?.tap)?.major > 17,
     tap16: semver.coerce(pkg.pkgJson?.devDependencies?.tap)?.major === 16,
     // booleans to control application of updates
     isForce,

--- a/lib/content/package-json.hbs
+++ b/lib/content/package-json.hbs
@@ -40,9 +40,19 @@
   },
   "templateVersion": {{{ del }}},
   "standard": {{{ del }}},
+  "nyc": {{#if tapOver17}}{
+    "exclude": {{{ json workspaceGlobs }}}
+  }{{else}}{{{ del }}}{{/if}},
   "tap": {
+    {{#if tapOver17}}
+    {{#if workspaceGlobs}}
+    "exclude": {{{ json workspaceGlobs }}},
+    {{/if}}
+    "test-ignore": {{{ del }}},
+    {{else}}
     {{#if workspacePaths}}
     "test-ignore": "^({{ join workspacePaths "|" }})/",
+    {{/if}}
     {{/if}}
     {{#if typescript}}
     {{#if tap16}}
@@ -54,7 +64,8 @@
     ],
     {{/if}}
     {{/if}}
-    "nyc-arg": {{#if tap18}}{{{ del }}}{{else}}[
+    "show-full-coverage": {{#if tapOver17}}true{{else}}{{{ del }}}{{/if}},
+    "nyc-arg": {{#if tapOver17}}{{{ del }}}{{else}}[
       {{#each workspaceGlobs}}
       "--exclude",
       "{{ . }}",

--- a/lib/content/package-json.hbs
+++ b/lib/content/package-json.hbs
@@ -50,6 +50,7 @@
     {{/if}}
     "test-ignore": {{{ del }}},
     {{else}}
+    "exclude": {{{ del }}},
     {{#if workspacePaths}}
     "test-ignore": "^({{ join workspacePaths "|" }})/",
     {{/if}}

--- a/lib/release/node-workspace-format.js
+++ b/lib/release/node-workspace-format.js
@@ -5,7 +5,8 @@ const { TagName } = require('release-please/build/src/util/tag-name.js')
 const { ROOT_PROJECT_PATH } = require('release-please/build/src/manifest.js')
 const { DEPS, link, wrapSpecs, list } = require('./util.js')
 
-/* istanbul ignore next: TODO fix flaky tests and enable coverage */
+/* TODO fix flaky tests and enable coverage */
+/* c8 ignore start */
 module.exports = class extends ManifestPlugin {
   static WORKSPACE_MESSAGE = (name, version) => `${DEPS}(workspace): ${name}@${version}`
 
@@ -95,3 +96,4 @@ module.exports = class extends ManifestPlugin {
     }
   }
 }
+/* c8 ignore end */

--- a/lib/release/release-manager.js
+++ b/lib/release/release-manager.js
@@ -165,13 +165,14 @@ class ReleaseManager {
       // If the url fails with anything but a 404 we want the process to blow
       // up because that means something is very wrong. This is a rare edge
       // case that isn't worth testing.
-      /* istanbul ignore else */
+
       if (r.statusCode === 200) {
         this.#info('Found release process from wiki')
         return r.body.text()
       } else if (r.statusCode === 404) {
         this.#info('No release process found in wiki, falling back to default process')
         return this.#getReleaseSteps()
+        /* c8 ignore next 3 */
       } else {
         throw new Error(`Release process fetch failed with status: ${r.statusCode}`)
       }

--- a/lib/release/release-please.js
+++ b/lib/release/release-please.js
@@ -10,7 +10,8 @@ const ChangelogNotes = require('./changelog.js')
 const NodeWorkspaceFormat = require('./node-workspace-format.js')
 const { getPublishTag, noop } = require('./util.js')
 
-/* istanbul ignore next: TODO fix flaky tests and enable coverage */
+/* TODO fix flaky tests and enable coverage */
+/* c8 ignore start */
 class ReleasePlease {
   #token
   #owner
@@ -166,5 +167,6 @@ class ReleasePlease {
     return releases.length ? releases : null
   }
 }
+/* c8 ignore end */
 
 module.exports = ReleasePlease

--- a/package.json
+++ b/package.json
@@ -73,19 +73,16 @@
     "eslint-config-prettier": "^9.1.0",
     "nock": "^13.3.8",
     "prettier": "^3.2.5",
-    "tap": "^16.0.0"
+    "tap": "^19.0.2"
   },
   "tap": {
     "timeout": 600,
-    "nyc-arg": [
-      "--exclude",
-      "workspace/test-workspace/**",
-      "--exclude",
-      "tap-snapshots/**"
-    ],
-    "test-ignore": "^(workspace/test-workspace)/",
     "node-arg": [
       "--no-experimental-fetch"
+    ],
+    "show-full-coverage": true,
+    "exclude": [
+      "workspace/test-workspace/**"
     ]
   },
   "templateOSS": {
@@ -98,5 +95,10 @@
   },
   "workspaces": [
     "workspace/test-workspace"
-  ]
+  ],
+  "nyc": {
+    "exclude": [
+      "workspace/test-workspace/**"
+    ]
+  }
 }

--- a/tap-snapshots/test/apply/files-snapshots.js.test.cjs
+++ b/tap-snapshots/test/apply/files-snapshots.js.test.cjs
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/apply/files-snapshots.js TAP private workspace > expect resolving Promise 1`] = `
+exports[`test/apply/files-snapshots.js > TAP > private workspace > promise must resolve to match snapshot 1`] = `
 .commitlintrc.js
 .eslintrc.js
 .github/actions/create-check/action.yml
@@ -42,7 +42,7 @@ workspaces/b/.gitignore
 workspaces/b/package.json
 `
 
-exports[`test/apply/files-snapshots.js TAP turn off add/rm types > expect resolving Promise 1`] = `
+exports[`test/apply/files-snapshots.js > TAP > turn off add/rm types > promise must resolve to match snapshot 1`] = `
 .commitlintrc.js
 .github/actions/create-check/action.yml
 .github/actions/install-latest-npm/action.yml
@@ -65,7 +65,7 @@ package.json
 release-please-config.json
 `
 
-exports[`test/apply/files-snapshots.js TAP turn off module > expect resolving Promise 1`] = `
+exports[`test/apply/files-snapshots.js > TAP > turn off module > promise must resolve to match snapshot 1`] = `
 .commitlintrc.js
 .github/actions/create-check/action.yml
 .github/actions/install-latest-npm/action.yml
@@ -88,7 +88,7 @@ package.json
 release-please-config.json
 `
 
-exports[`test/apply/files-snapshots.js TAP turn off repo > expect resolving Promise 1`] = `
+exports[`test/apply/files-snapshots.js > TAP > turn off repo > promise must resolve to match snapshot 1`] = `
 .eslintrc.js
 .gitignore
 .npmrc
@@ -98,11 +98,11 @@ package.json
 SECURITY.md
 `
 
-exports[`test/apply/files-snapshots.js TAP turn off root > expect resolving Promise 1`] = `
+exports[`test/apply/files-snapshots.js > TAP > turn off root > promise must resolve to match snapshot 1`] = `
 package.json
 `
 
-exports[`test/apply/files-snapshots.js TAP turn off specific files > expect resolving Promise 1`] = `
+exports[`test/apply/files-snapshots.js > TAP > turn off specific files > promise must resolve to match snapshot 1`] = `
 .eslintrc.yml
 .github/actions/create-check/action.yml
 .github/actions/install-latest-npm/action.yml
@@ -131,7 +131,7 @@ release-please-config.json
 SECURITY.md
 `
 
-exports[`test/apply/files-snapshots.js TAP workspaces > expect resolving Promise 1`] = `
+exports[`test/apply/files-snapshots.js > TAP > workspaces > promise must resolve to match snapshot 1`] = `
 .github/actions/create-check/action.yml
 .github/actions/install-latest-npm/action.yml
 .github/dependabot.yml
@@ -158,7 +158,7 @@ workspaces/d/.gitignore
 workspaces/d/package.json
 `
 
-exports[`test/apply/files-snapshots.js TAP workspaces only (like npm/cli) > expect resolving Promise 1`] = `
+exports[`test/apply/files-snapshots.js > TAP > workspaces only (like npm/cli) > promise must resolve to match snapshot 1`] = `
 .github/actions/create-check/action.yml
 .github/actions/install-latest-npm/action.yml
 .github/dependabot.yml
@@ -182,7 +182,7 @@ workspaces/b/.gitignore
 workspaces/b/package.json
 `
 
-exports[`test/apply/files-snapshots.js TAP workspaces with relative content path > expect resolving Promise 1`] = `
+exports[`test/apply/files-snapshots.js > TAP > workspaces with relative content path > promise must resolve to match snapshot 1`] = `
 content_dir/index.js
 content_dir2/index.js
 package.json

--- a/tap-snapshots/test/apply/source-snapshots.js.test.cjs
+++ b/tap-snapshots/test/apply/source-snapshots.js.test.cjs
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/apply/source-snapshots.js TAP root only > expect resolving Promise 1`] = `
+exports[`test/apply/source-snapshots.js > TAP > root only > promise must resolve to match snapshot 1`] = `
 .commitlintrc.js
 ========================================
 /* This file is automatically added by @npmcli/template-oss. Do not edit. */
@@ -1425,7 +1425,7 @@ If the vulnerability you have found is [in scope for the GitHub Bug Bounty Progr
 Thanks for helping make GitHub safe for everyone.
 `
 
-exports[`test/apply/source-snapshots.js TAP with content path > expect resolving Promise 1`] = `
+exports[`test/apply/source-snapshots.js > TAP > with content path > promise must resolve to match snapshot 1`] = `
 content_dir/index.js
 ========================================
 module.exports={}
@@ -1443,7 +1443,7 @@ package.json
 }
 `
 
-exports[`test/apply/source-snapshots.js TAP with workspaces > expect resolving Promise 1`] = `
+exports[`test/apply/source-snapshots.js > TAP > with workspaces > promise must resolve to match snapshot 1`] = `
 .commitlintrc.js
 ========================================
 /* This file is automatically added by @npmcli/template-oss. Do not edit. */
@@ -3270,7 +3270,7 @@ workspaces/b/package.json
 }
 `
 
-exports[`test/apply/source-snapshots.js TAP workspaces only > expect resolving Promise 1`] = `
+exports[`test/apply/source-snapshots.js > TAP > workspaces only > promise must resolve to match snapshot 1`] = `
 .github/actions/create-check/action.yml
 ========================================
 # This file is automatically added by @npmcli/template-oss. Do not edit.
@@ -4634,7 +4634,7 @@ workspaces/b/package.json
 }
 `
 
-exports[`test/apply/source-snapshots.js TAP workspaces with nested content path > expect resolving Promise 1`] = `
+exports[`test/apply/source-snapshots.js > TAP > workspaces with nested content path > promise must resolve to match snapshot 1`] = `
 content_dir/index.js
 ========================================
 module.exports={}

--- a/tap-snapshots/test/bin/check.js.test.cjs
+++ b/tap-snapshots/test/bin/check.js.test.cjs
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/bin/check.js TAP problems > must match snapshot 1`] = `
+exports[`test/bin/check.js > TAP > problems > must match snapshot 1`] = `
 
 Some problems were detected:
 

--- a/tap-snapshots/test/check/diff-snapshots.js.test.cjs
+++ b/tap-snapshots/test/check/diff-snapshots.js.test.cjs
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/check/diff-snapshots.js TAP different headers > expect resolving Promise 1`] = `
+exports[`test/check/diff-snapshots.js > TAP > different headers > promise must resolve to match snapshot 1`] = `
 Some problems were detected:
 
 -------------------------------------------------------------------
@@ -21,7 +21,7 @@ To correct it: npx template-oss-apply --force
 -------------------------------------------------------------------
 `
 
-exports[`test/check/diff-snapshots.js TAP json delete > expect resolving Promise 1`] = `
+exports[`test/check/diff-snapshots.js > TAP > json delete > promise must resolve to match snapshot 1`] = `
 Some problems were detected:
 
 -------------------------------------------------------------------
@@ -39,7 +39,7 @@ To correct it: npx template-oss-apply --force
 -------------------------------------------------------------------
 `
 
-exports[`test/check/diff-snapshots.js TAP json merge > initial check 1`] = `
+exports[`test/check/diff-snapshots.js > TAP > json merge > initial check 1`] = `
 Some problems were detected:
 
 -------------------------------------------------------------------
@@ -56,7 +56,7 @@ To correct it: npx template-oss-apply --force
 -------------------------------------------------------------------
 `
 
-exports[`test/check/diff-snapshots.js TAP json overwrite > expect resolving Promise 1`] = `
+exports[`test/check/diff-snapshots.js > TAP > json overwrite > promise must resolve to match snapshot 1`] = `
 Some problems were detected:
 
 -------------------------------------------------------------------
@@ -73,7 +73,7 @@ To correct it: npx template-oss-apply --force
 -------------------------------------------------------------------
 `
 
-exports[`test/check/diff-snapshots.js TAP unknown file type > expect resolving Promise 1`] = `
+exports[`test/check/diff-snapshots.js > TAP > unknown file type > promise must resolve to match snapshot 1`] = `
 Some problems were detected:
 
 -------------------------------------------------------------------
@@ -87,7 +87,7 @@ To correct it: npx template-oss-apply --force
 -------------------------------------------------------------------
 `
 
-exports[`test/check/diff-snapshots.js TAP update and remove errors > expect resolving Promise 1`] = `
+exports[`test/check/diff-snapshots.js > TAP > update and remove errors > promise must resolve to match snapshot 1`] = `
 Some problems were detected:
 
 -------------------------------------------------------------------
@@ -97,7 +97,7 @@ The repo file audit.yml needs to be updated:
   .github/workflows/audit.yml
   ========================================
   [@npmcli/template-oss ERROR] There was an erroring getting the target file
-  [@npmcli/template-oss ERROR] Error: {{ROOT}}/test/check/tap-testdir-diff-snapshots-update-and-remove-errors/.github/workflows/audit.yml
+  [@npmcli/template-oss ERROR] Error: {{ROOT}}/.tap/fixtures/test-check-diff-snapshots.js-update-and-remove-errors/.github/workflows/audit.yml
   
   YAMLParseError: Implicit keys need to be on a single line at line 42, column 1:
   
@@ -222,7 +222,7 @@ To correct it: npx template-oss-apply --force
 -------------------------------------------------------------------
 `
 
-exports[`test/check/diff-snapshots.js TAP will diff json > expect resolving Promise 1`] = `
+exports[`test/check/diff-snapshots.js > TAP > will diff json > promise must resolve to match snapshot 1`] = `
 Some problems were detected:
 
 -------------------------------------------------------------------

--- a/tap-snapshots/test/check/snapshots.js.test.cjs
+++ b/tap-snapshots/test/check/snapshots.js.test.cjs
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/check/snapshots.js TAP changelog > expect resolving Promise 1`] = `
+exports[`test/check/snapshots.js > TAP > changelog > promise must resolve to match snapshot 1`] = `
 Some problems were detected:
 
 -------------------------------------------------------------------
@@ -22,7 +22,7 @@ To correct it: reformat the changelog to have the correct heading
 -------------------------------------------------------------------
 `
 
-exports[`test/check/snapshots.js TAP check empty dir > expect resolving Promise 1`] = `
+exports[`test/check/snapshots.js > TAP > check empty dir > promise must resolve to match snapshot 1`] = `
 Some problems were detected:
 
 -------------------------------------------------------------------
@@ -111,7 +111,7 @@ To correct it: npm rm @npmcli/template-oss @npmcli/eslint-config tap && npm i @n
 -------------------------------------------------------------------
 `
 
-exports[`test/check/snapshots.js TAP gitignore > expect resolving Promise 1`] = `
+exports[`test/check/snapshots.js > TAP > gitignore > promise must resolve to match snapshot 1`] = `
 Some problems were detected:
 
 -------------------------------------------------------------------
@@ -156,7 +156,7 @@ To correct it: move files to not match one of the following patterns:
 -------------------------------------------------------------------
 `
 
-exports[`test/check/snapshots.js TAP gitignore with workspaces workspace > expect resolving Promise 1`] = `
+exports[`test/check/snapshots.js > TAP > gitignore with workspaces workspace > promise must resolve to match snapshot 1`] = `
 Some problems were detected:
 
 -------------------------------------------------------------------
@@ -258,7 +258,7 @@ To correct it: move files to not match one of the following patterns:
 -------------------------------------------------------------------
 `
 
-exports[`test/check/snapshots.js TAP not ok without required > expect resolving Promise 1`] = `
+exports[`test/check/snapshots.js > TAP > not ok without required > promise must resolve to match snapshot 1`] = `
 Some problems were detected:
 
 -------------------------------------------------------------------
@@ -274,7 +274,7 @@ To correct it: npm rm @npmcli/template-oss @npmcli/eslint-config tap && npm i @n
 -------------------------------------------------------------------
 `
 
-exports[`test/check/snapshots.js TAP unwanted > expect resolving Promise 1`] = `
+exports[`test/check/snapshots.js > TAP > unwanted > promise must resolve to match snapshot 1`] = `
 Some problems were detected:
 
 -------------------------------------------------------------------
@@ -288,7 +288,7 @@ To correct it: npm rm eslint
 -------------------------------------------------------------------
 `
 
-exports[`test/check/snapshots.js TAP workspaces with empty dir > expect resolving Promise 1`] = `
+exports[`test/check/snapshots.js > TAP > workspaces with empty dir > promise must resolve to match snapshot 1`] = `
 Some problems were detected:
 
 -------------------------------------------------------------------

--- a/tap-snapshots/test/release/release-manager-mock-release-manager.js.test.cjs
+++ b/tap-snapshots/test/release/release-manager-mock-release-manager.js.test.cjs
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/release/release-manager.js TAP mock release manager > must match snapshot 1`] = `
+exports[`test/release/release-manager.js > TAP > mock release manager > must match snapshot 1`] = `
 ### Release Checklist for v4.0.5
 
 - [ ] 1. Checkout the release branch and test

--- a/tap-snapshots/test/release/release-manager-npm-cli.js.test.cjs
+++ b/tap-snapshots/test/release/release-manager-npm-cli.js.test.cjs
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/release/release-manager.js TAP npm/cli > must match snapshot 1`] = `
+exports[`test/release/release-manager.js > TAP > npm/cli > must match snapshot 1`] = `
 ### Release Checklist for v10.2.5
 
 - [ ] 1. Checkout the release branch

--- a/tap-snapshots/test/release/release-manager-npm-cli.js.test.cjs
+++ b/tap-snapshots/test/release/release-manager-npm-cli.js.test.cjs
@@ -152,7 +152,7 @@ exports[`test/release/release-manager.js > TAP > npm/cli > must match snapshot 1
 - [ ] 11. Label and fast-track \`nodejs/node\` PR
 
     > **Note**:
-    > This requires being a \`nodejs\` collaborator. Currently @lukekarrys is so ping them to do these steps!
+    > This requires being a \`nodejs\` collaborator. This could be you! 
 
     - Thumbs-up reaction on the Fast-track comment
     - Add an LGTM / Approval

--- a/tap-snapshots/test/release/release-manager-prerelease.js.test.cjs
+++ b/tap-snapshots/test/release/release-manager-prerelease.js.test.cjs
@@ -143,7 +143,7 @@ exports[`test/release/release-manager.js > TAP > prerelease > must match snapsho
 - [ ] 10. Label and fast-track \`nodejs/node\` PR
 
     > **Note**:
-    > This requires being a \`nodejs\` collaborator. Currently @lukekarrys is so ping them to do these steps!
+    > This requires being a \`nodejs\` collaborator. This could be you! 
 
     - Thumbs-up reaction on the Fast-track comment
     - Add an LGTM / Approval

--- a/tap-snapshots/test/release/release-manager-prerelease.js.test.cjs
+++ b/tap-snapshots/test/release/release-manager-prerelease.js.test.cjs
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/release/release-manager.js TAP prerelease > must match snapshot 1`] = `
+exports[`test/release/release-manager.js > TAP > prerelease > must match snapshot 1`] = `
 ### Release Checklist for v10.0.0-pre.0
 
 - [ ] 1. Checkout the release branch

--- a/tap-snapshots/test/release/release-manager-publish-and-lockfile.js.test.cjs
+++ b/tap-snapshots/test/release/release-manager-publish-and-lockfile.js.test.cjs
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/release/release-manager.js TAP publish and lockfile > must match snapshot 1`] = `
+exports[`test/release/release-manager.js > TAP > publish and lockfile > must match snapshot 1`] = `
 ### Release Checklist for v7.5.4
 
 - [ ] 1. Approve this PR

--- a/tap-snapshots/test/release/release-manager-single-release.js.test.cjs
+++ b/tap-snapshots/test/release/release-manager-single-release.js.test.cjs
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/release/release-manager.js TAP single release > must match snapshot 1`] = `
+exports[`test/release/release-manager.js > TAP > single release > must match snapshot 1`] = `
 ### Release Checklist for v7.5.4
 
 - [ ] 1. Checkout the release branch and test

--- a/tap-snapshots/test/release/release-manager-workspace-names.js.test.cjs
+++ b/tap-snapshots/test/release/release-manager-workspace-names.js.test.cjs
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/release/release-manager.js TAP workspace names > expect resolving Promise 1`] = `
+exports[`test/release/release-manager.js > TAP > workspace names > promise must resolve to match snapshot 1`] = `
 ### Release Checklist for v10.2.2
 
 - [ ] 1. Checkout the release branch

--- a/tap-snapshots/test/release/release-manager-workspace-names.js.test.cjs
+++ b/tap-snapshots/test/release/release-manager-workspace-names.js.test.cjs
@@ -152,7 +152,7 @@ exports[`test/release/release-manager.js > TAP > workspace names > promise must 
 - [ ] 11. Label and fast-track \`nodejs/node\` PR
 
     > **Note**:
-    > This requires being a \`nodejs\` collaborator. Currently @lukekarrys is so ping them to do these steps!
+    > This requires being a \`nodejs\` collaborator. This could be you! 
 
     - Thumbs-up reaction on the Fast-track comment
     - Add an LGTM / Approval

--- a/test/apply/tap.js
+++ b/test/apply/tap.js
@@ -31,9 +31,6 @@ t.test('tap@16', async t => {
   await s.apply()
   const pkg = await s.readJson('package.json')
   t.strictSame(pkg.tap, {
-    'nyc-arg': [
-      '--exclude',
-      'tap-snapshots/**',
-    ],
+    'nyc-arg': ['--exclude', 'tap-snapshots/**'],
   })
 })

--- a/test/apply/tap.js
+++ b/test/apply/tap.js
@@ -13,7 +13,9 @@ t.test('tap@18', async t => {
 
   await s.apply()
   const pkg = await s.readJson('package.json')
-  t.strictSame(pkg.tap, {})
+  t.strictSame(pkg.tap, {
+    'show-full-coverage': true,
+  })
 })
 
 t.test('tap@16', async t => {
@@ -29,6 +31,9 @@ t.test('tap@16', async t => {
   await s.apply()
   const pkg = await s.readJson('package.json')
   t.strictSame(pkg.tap, {
-    'nyc-arg': ['--exclude', 'tap-snapshots/**'],
+    'nyc-arg': [
+      '--exclude',
+      'tap-snapshots/**',
+    ],
   })
 })

--- a/test/bin/apply.js
+++ b/test/bin/apply.js
@@ -1,7 +1,7 @@
 const t = require('tap')
 
 const templateApply = mocks =>
-  t.mock(
+  t.mockRequire(
     '../../bin/apply.js',
     mocks && {
       '../../lib/apply/index.js': async () => mocks(),

--- a/test/bin/check.js
+++ b/test/bin/check.js
@@ -1,7 +1,7 @@
 const t = require('tap')
 
 const templateCheck = mocks =>
-  t.mock(
+  t.mockRequire(
     '../../bin/check.js',
     mocks && {
       '../../lib/check/index.js': async () => mocks(),

--- a/test/fixtures/mock-release.js
+++ b/test/fixtures/mock-release.js
@@ -1,9 +1,8 @@
 const nock = require('nock')
-const { resolve, relative, dirname, sep, join, basename, extname } = require('path')
+const { resolve, dirname, join, basename, extname } = require('path')
 const fs = require('fs')
 
 const DIR = __dirname
-const CWD = process.cwd()
 const RECORD = 'NOCK_RECORD' in process.env ? true : undefined
 
 // These are the live GitHub repo and branch that are used to

--- a/test/fixtures/mock-release.js
+++ b/test/fixtures/mock-release.js
@@ -1,5 +1,5 @@
 const nock = require('nock')
-const { resolve, relative, dirname, sep, join, basename } = require('path')
+const { resolve, relative, dirname, sep, join, basename, extname } = require('path')
 const fs = require('fs')
 
 const DIR = __dirname
@@ -12,9 +12,12 @@ const REPO = 'npm/npm-cli-release-please'
 const BRANCH = 'template-oss-mock-testing-branch-do-not-delete'
 
 const getPath = t => {
-  const fixtureName = relative(CWD, t.testdirName).split(`${sep}tap-testdir-`)[1]
+  const fullExt = extname(t.testdirName)
+  const testName = fullExt.replace(/\.js-/, '')
+  const testFileName = basename(t.testdirName, fullExt).replace(/^test-release-/, '')
+  const fixtureName = `${testFileName}-${testName}`
   return {
-    fixtureName: basename(fixtureName),
+    fixtureName,
     fixturePath: resolve(DIR, 'nocks', `${fixtureName}.json`),
   }
 }
@@ -61,7 +64,7 @@ const setup = t => {
 }
 
 const releasePlease = async (t, { setup: s, ...opts } = {}) => {
-  const ReleasePlease = t.mock('../../lib/release/release-please.js')
+  const ReleasePlease = t.mockRequire('../../lib/release/release-please.js')
   try {
     return await ReleasePlease.run({
       token: s.token,
@@ -82,7 +85,7 @@ const releasePlease = async (t, { setup: s, ...opts } = {}) => {
 
 const releaseManager = (t, { cwd = t.testdir({ 'package.json': '{"name":"pkg"}' }), ...opts } = {}) => {
   const s = setup(t)
-  const ReleaseManager = t.mock('../../lib/release/release-manager.js')
+  const ReleaseManager = t.mockRequire('../../lib/release/release-manager.js')
   return ReleaseManager.run({
     token: s.token,
     repo: REPO,

--- a/test/setup.js
+++ b/test/setup.js
@@ -88,8 +88,8 @@ const setupRoot = async (t, root, mocks) => {
     return Object.fromEntries(files.map((f, i) => [f, contents[i]]))
   }
 
-  const apply = t.mock('../lib/apply/index.js', mocks)
-  const check = t.mock('../lib/check/index.js', mocks)
+  const apply = t.mockRequire('../lib/apply/index.js', mocks)
+  const check = t.mockRequire('../lib/check/index.js', mocks)
 
   return {
     root,


### PR DESCRIPTION
* currently `tap.nyc-args` is only removed for 18 not 19 😢 
* `tap-snapshots` is ignored by default
* adds `tap.show-full-coverage` for > 17
* updates snaps to use new `>` delimiter syntax
* `t.mock` -> `t.mockRequire`
* had to reconstruct fixtureName to match old one because fixtures have different names now, ideally, would like to rm all this code and use https://github.com/npm/tap-nock and rename nock snapshots

