### PR TITLE
fix: Use `include-workspace-root` for `/main` in Post Dependabot

### DIFF
--- a/.github/actions/create-check/action.yml
+++ b/.github/actions/create-check/action.yml
@@ -25,7 +25,7 @@ runs:
       with:
         result-encoding: string
         script: |
-          const { repo: { owner, repo}, runId, serverUrl } = context          
+          const { repo: { owner, repo}, runId, serverUrl } = context
           const { JOB_NAME, SHA } = process.env
 
           const job = await github.rest.actions.listJobsForWorkflowRun({

--- a/.github/actions/install-latest-npm/action.yml
+++ b/.github/actions/install-latest-npm/action.yml
@@ -44,7 +44,7 @@ runs:
             MATCH=$SPEC
             echo "Found compatible version: npm@$MATCH"
             break
-          fi  
+          fi
         done
 
         if [ -z $MATCH ]; then

--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -49,7 +49,7 @@ jobs:
         id: flags
         run: |
           dependabot_dir="${{ steps.metadata.outputs.directory }}"
-          if [[ "$dependabot_dir" == "/" ]]; then
+          if [[ "$dependabot_dir" == "/" || "$dependabot_dir" == "/main" ]]; then
             echo "workspace=-iwr" >> $GITHUB_OUTPUT
           else
             # strip leading slash from directory so it works as a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 GitHub takes the security of our software products and services seriously, including the open source code repositories managed through our GitHub organizations, such as [GitHub](https://github.com/GitHub).
 
-If you believe you have found a security vulnerability in this GitHub-owned open source repository, you can report it to us in one of two ways. 
+If you believe you have found a security vulnerability in this GitHub-owned open source repository, you can report it to us in one of two ways.
 
 If the vulnerability you have found is *not* [in scope for the GitHub Bug Bounty Program](https://bounty.github.com/#scope) or if you do not wish to be considered for a bounty reward, please report the issue to us directly through [opensource-security@github.com](mailto:opensource-security@github.com).
 

--- a/lib/content/SECURITY-md.hbs
+++ b/lib/content/SECURITY-md.hbs
@@ -1,6 +1,6 @@
 GitHub takes the security of our software products and services seriously, including the open source code repositories managed through our GitHub organizations, such as [GitHub](https://github.com/GitHub).
 
-If you believe you have found a security vulnerability in this GitHub-owned open source repository, you can report it to us in one of two ways. 
+If you believe you have found a security vulnerability in this GitHub-owned open source repository, you can report it to us in one of two ways.
 
 If the vulnerability you have found is *not* [in scope for the GitHub Bug Bounty Program](https://bounty.github.com/#scope) or if you do not wish to be considered for a bounty reward, please report the issue to us directly through [opensource-security@github.com](mailto:opensource-security@github.com).
 

--- a/lib/content/action-create-check-yml.hbs
+++ b/lib/content/action-create-check-yml.hbs
@@ -23,7 +23,7 @@ runs:
       with:
         result-encoding: string
         script: |
-          const { repo: { owner, repo}, runId, serverUrl } = context          
+          const { repo: { owner, repo}, runId, serverUrl } = context
           const { JOB_NAME, SHA } = process.env
 
           const job = await github.rest.actions.listJobsForWorkflowRun({

--- a/lib/content/action-install-latest-npm-yml.hbs
+++ b/lib/content/action-install-latest-npm-yml.hbs
@@ -42,7 +42,7 @@ runs:
             MATCH=$SPEC
             echo "Found compatible version: npm@$MATCH"
             break
-          fi  
+          fi
         done
 
         if [ -z $MATCH ]; then

--- a/lib/content/post-dependabot-yml.hbs
+++ b/lib/content/post-dependabot-yml.hbs
@@ -26,7 +26,7 @@ jobs:
         id: flags
         run: |
           dependabot_dir="$\{{ steps.metadata.outputs.directory }}"
-          if [[ "$dependabot_dir" == "/" ]]; then
+          if [[ "$dependabot_dir" == "/" || "$dependabot_dir" == "/{{ releaseBranch }}" ]]; then
             echo "workspace=-iwr" >> $GITHUB_OUTPUT
           else
             # strip leading slash from directory so it works as a
@@ -64,7 +64,7 @@ jobs:
         run: |
           git commit -am "$\{{ steps.apply.outputs.message }}"
           git push
-      
+
       # If the previous step failed, then reset the commit and remove any workflow changes
       # and attempt to commit and push again. This is helpful because we will have a commit
       # with the correct prefix that we can then --amend with @npmcli/stafftools later.
@@ -98,4 +98,3 @@ jobs:
           echo "This PR has a breaking change. Run 'npx -p @npmcli/stafftools gh template-oss-fix'"
           echo "for more information on how to fix this with a BREAKING CHANGE footer."
           exit 1
-          

--- a/lib/util/dependabot.js
+++ b/lib/util/dependabot.js
@@ -1,7 +1,7 @@
 const { name: NAME } = require('../../package.json')
 const { minimatch } = require('minimatch')
 
-const parseDependabotConfig = v => (typeof v === 'string' ? { strategy: v } : v ?? {})
+const parseDependabotConfig = v => (typeof v === 'string' ? { strategy: v } : (v ?? {}))
 
 module.exports = (config, defaultConfig, branches) => {
   const { dependabot } = config

--- a/tap-snapshots/test/apply/source-snapshots.js.test.cjs
+++ b/tap-snapshots/test/apply/source-snapshots.js.test.cjs
@@ -72,7 +72,7 @@ runs:
       with:
         result-encoding: string
         script: |
-          const { repo: { owner, repo}, runId, serverUrl } = context          
+          const { repo: { owner, repo}, runId, serverUrl } = context
           const { JOB_NAME, SHA } = process.env
 
           const job = await github.rest.actions.listJobsForWorkflowRun({
@@ -146,7 +146,7 @@ runs:
             MATCH=$SPEC
             echo "Found compatible version: npm@$MATCH"
             break
-          fi  
+          fi
         done
 
         if [ -z $MATCH ]; then
@@ -725,7 +725,7 @@ jobs:
         id: flags
         run: |
           dependabot_dir="\${{ steps.metadata.outputs.directory }}"
-          if [[ "$dependabot_dir" == "/" ]]; then
+          if [[ "$dependabot_dir" == "/" || "$dependabot_dir" == "/main" ]]; then
             echo "workspace=-iwr" >> $GITHUB_OUTPUT
           else
             # strip leading slash from directory so it works as a
@@ -1414,7 +1414,7 @@ SECURITY.md
 
 GitHub takes the security of our software products and services seriously, including the open source code repositories managed through our GitHub organizations, such as [GitHub](https://github.com/GitHub).
 
-If you believe you have found a security vulnerability in this GitHub-owned open source repository, you can report it to us in one of two ways. 
+If you believe you have found a security vulnerability in this GitHub-owned open source repository, you can report it to us in one of two ways.
 
 If the vulnerability you have found is *not* [in scope for the GitHub Bug Bounty Program](https://bounty.github.com/#scope) or if you do not wish to be considered for a bounty reward, please report the issue to us directly through [opensource-security@github.com](mailto:opensource-security@github.com).
 
@@ -1512,7 +1512,7 @@ runs:
       with:
         result-encoding: string
         script: |
-          const { repo: { owner, repo}, runId, serverUrl } = context          
+          const { repo: { owner, repo}, runId, serverUrl } = context
           const { JOB_NAME, SHA } = process.env
 
           const job = await github.rest.actions.listJobsForWorkflowRun({
@@ -1586,7 +1586,7 @@ runs:
             MATCH=$SPEC
             echo "Found compatible version: npm@$MATCH"
             break
-          fi  
+          fi
         done
 
         if [ -z $MATCH ]; then
@@ -2383,7 +2383,7 @@ jobs:
         id: flags
         run: |
           dependabot_dir="\${{ steps.metadata.outputs.directory }}"
-          if [[ "$dependabot_dir" == "/" ]]; then
+          if [[ "$dependabot_dir" == "/" || "$dependabot_dir" == "/main" ]]; then
             echo "workspace=-iwr" >> $GITHUB_OUTPUT
           else
             # strip leading slash from directory so it works as a
@@ -3099,7 +3099,7 @@ SECURITY.md
 
 GitHub takes the security of our software products and services seriously, including the open source code repositories managed through our GitHub organizations, such as [GitHub](https://github.com/GitHub).
 
-If you believe you have found a security vulnerability in this GitHub-owned open source repository, you can report it to us in one of two ways. 
+If you believe you have found a security vulnerability in this GitHub-owned open source repository, you can report it to us in one of two ways.
 
 If the vulnerability you have found is *not* [in scope for the GitHub Bug Bounty Program](https://bounty.github.com/#scope) or if you do not wish to be considered for a bounty reward, please report the issue to us directly through [opensource-security@github.com](mailto:opensource-security@github.com).
 
@@ -3300,7 +3300,7 @@ runs:
       with:
         result-encoding: string
         script: |
-          const { repo: { owner, repo}, runId, serverUrl } = context          
+          const { repo: { owner, repo}, runId, serverUrl } = context
           const { JOB_NAME, SHA } = process.env
 
           const job = await github.rest.actions.listJobsForWorkflowRun({
@@ -3374,7 +3374,7 @@ runs:
             MATCH=$SPEC
             echo "Found compatible version: npm@$MATCH"
             break
-          fi  
+          fi
         done
 
         if [ -z $MATCH ]; then
@@ -3907,7 +3907,7 @@ jobs:
         id: flags
         run: |
           dependabot_dir="\${{ steps.metadata.outputs.directory }}"
-          if [[ "$dependabot_dir" == "/" ]]; then
+          if [[ "$dependabot_dir" == "/" || "$dependabot_dir" == "/main" ]]; then
             echo "workspace=-iwr" >> $GITHUB_OUTPUT
           else
             # strip leading slash from directory so it works as a


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

`steps.metadata.outputs.directory` is set to `/main`, not `/`, when `package.json` is at the root of the repository. I suspect adding `target-branch` to `dependabot.yml` (#330) added a `main` segment to Dependabot PR branch names, which changed the value of `steps.metadata.outputs.directory`.

By fixing this issue, we shouldn't need to routinely use stafftools to fix up template-oss Dependabot PRs. 🤞🏼 

I couldn't quickly find a `bump @npmcli/template-oss` Dependabot PR for a workspace to inspect `steps.metadata.outputs.directory` and fix workspaces support. If that's important, we may want to either enable Dependabot for `npm/cli` or create a separate `template-oss-test` repo. It's not clear if Dependabot will create a PR for `workspace/test-workspace` upon our next release.

### Example Dependabot PR branch names

The first PR updates just `@npmcli/template-oss`. The second updates multiple dependencies including `@npmcli/template-oss`.

PR | branch name | segments | steps.metadata.outputs.directory
-|-|-|-
https://github.com/npm/agent/pull/110 | `dependabot/npm_and_yarn/main/npmcli/template-oss-4.23.0` | 5 | `/main`
https://github.com/npm/statusboard/pull/877 | `dependabot/npm_and_yarn/main/dependency-updates-4de8b5bfcf` | 4 | `/`

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

Failed "Post Dependabot" run: https://github.com/npm/agent/actions/runs/9963674341/job/27530225303

Fix manually tested here: https://github.com/npm/agent/pull/110/commits/ef85b0854e5ee9c26c289ceeba083edc3339a2bb  

[branchNameToDirectoryName](https://github.com/dependabot/fetch-metadata/blob/ffa2dc8ffecf17d26f6a81b83f9ef5edd33ba93a/src/dependabot/update_metadata.ts#L31)

Bug report: https://github.com/dependabot/fetch-metadata/issues/540