### PR TITLE
fix: Install an exact version of `@github/prettier-config`

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -235,7 +235,7 @@ const getFullConfig = async ({
       ...pkgConfig.requiredPackages.devDependencies,
       'prettier',
       'eslint-config-prettier',
-      '@github/prettier-config',
+      '@github/prettier-config@0.0.6',
     ])
   }
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

This matches what I've seen us install in practice. See https://github.com/npm/template-oss/blob/4ef5cf6be626cb5265486420634ad231832540ab/package.json#L70 and https://github.com/npm/template-oss/blob/b35bca55b28b41773aa6b936fc626bc15b40eae5/test/apply/lint.js#L50-L52

### Sample postlint guidance

Instead of `@github/prettier-config@*`, it tells you to install `@github/prettier-config@0.0.6` with the `--save-exact` flag.

```
% npm uninstall prettier && npm uninstall @github/prettier-config
...

% npm run postlint
> @npmcli/template-oss@4.23.1 postlint
> template-oss-check


Some problems were detected:

-------------------------------------------------------------------

The following required devDependencies were not found:

  prettier
  @github/prettier-config@0.0.6

To correct it: npm rm prettier @github/prettier-config && npm i prettier@* --save-dev && npm i @github/prettier-config@0.0.6 --save-dev --save-exact

-------------------------------------------------------------------
```

#### Exact version enforcement

**semver range**

```
% npm i @github/prettier-config@latest --save-dev
...

% npm pkg get devDependencies."@github/prettier-config" 
"^0.0.6"

% npm run postlint                                     

> @npmcli/template-oss@4.23.1 postlint
> template-oss-check


Some problems were detected:

-------------------------------------------------------------------

The following required devDependencies were not found:

  @github/prettier-config@0.0.6

To correct it: npm rm @github/prettier-config && npm i @github/prettier-config@0.0.6 --save-dev --save-exact

-------------------------------------------------------------------
```

**Exact version**

```
% npm i @github/prettier-config@0.0.6 --save-dev --save-exact
...

% npm pkg get devDependencies."@github/prettier-config"
"0.0.6"
% npm run postlint

> @npmcli/template-oss@4.23.1 postlint
> template-oss-check

% 
```

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

Follow-up to https://github.com/npm/template-oss/pull/447