### PR TITLE
fix: Don't restrict length for commit message footer

### DIFF
--- a/.commitlintrc.js
+++ b/.commitlintrc.js
@@ -7,5 +7,6 @@ module.exports = {
     'header-max-length': [2, 'always', 80],
     'subject-case': [0],
     'body-max-line-length': [0],
+    'footer-max-line-length': [0],
   },
 }

--- a/lib/content/commitlintrc-js.hbs
+++ b/lib/content/commitlintrc-js.hbs
@@ -5,5 +5,6 @@ module.exports = {
     'header-max-length': [2, 'always', 80],
     'subject-case': [0],
     'body-max-line-length': [0],
+    'footer-max-line-length': [0],
   },
 }

--- a/tap-snapshots/test/apply/source-snapshots.js.test.cjs
+++ b/tap-snapshots/test/apply/source-snapshots.js.test.cjs
@@ -17,6 +17,7 @@ module.exports = {
     'header-max-length': [2, 'always', 80],
     'subject-case': [0],
     'body-max-line-length': [0],
+    'footer-max-line-length': [0],
   },
 }
 
@@ -1455,6 +1456,7 @@ module.exports = {
     'header-max-length': [2, 'always', 80],
     'subject-case': [0],
     'body-max-line-length': [0],
+    'footer-max-line-length': [0],
   },
 }
 


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

A breaking change footer like the one below is over 100 characters, resulting in commitlint CI failures.

```
BREAKING CHANGE: `ssri` is now compatible with the following semver range for node: `^16.13.0 || >=18.0.0`
```

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

Example CI failure: https://github.com/npm/ssri/actions/runs/10169599799/job/28126863705#step:7:12

Associated PR: https://github.com/npm/ssri/pull/137