### PR TITLE
fix: no duplicate changelog entries

### DIFF
--- a/lib/release/changelog.js
+++ b/lib/release/changelog.js
@@ -51,7 +51,7 @@ class Changelog {
       return ''
     }
 
-    return body.join('\n\n').trim()
+    return body.join('\n').trim()
   }
 }
 
@@ -154,7 +154,7 @@ class ChangelogNotes {
     const subject = wrapSpecs(commit.bareMessage)
     entry.push([scope, subject].filter(Boolean).join(' '))
 
-    // A list og the authors github handles or names
+    // A list of the authors github handles or names
     if (commit.authors.length) {
       entry.push(`(${commit.authors.join(', ')})`)
     }


### PR DESCRIPTION
release-please will re-inject the entire changelog when looking
for the existing dependencies section in some cases. Have multiple
newlines between sections of the changelog triggers that behavior
because it looks for lines that do no start with '*' but it does
not account for empty lines
