### PR TITLE
fix:  correct versions with prereleases

### DIFF
--- a/lib/release/release-please.js
+++ b/lib/release/release-please.js
@@ -1,6 +1,4 @@
 const RP = require('release-please')
-const { DefaultVersioningStrategy } = require('release-please/build/src/versioning-strategies/default.js')
-const { PrereleaseVersioningStrategy } = require('release-please/build/src/versioning-strategies/prerelease.js')
 const { ROOT_PROJECT_PATH } = require('release-please/build/src/manifest.js')
 const { CheckpointLogger, logger } = require('release-please/build/src/util/logger.js')
 const assert = require('assert')
@@ -9,6 +7,7 @@ const omit = require('just-omit')
 const ChangelogNotes = require('./changelog.js')
 const NodeWorkspaceFormat = require('./node-workspace-format.js')
 const { getPublishTag, noop } = require('./util.js')
+const { SemverVersioningStrategy } = require('./semver-versioning-strategy.js')
 
 /* istanbul ignore next: TODO fix flaky tests and enable coverage */
 class ReleasePlease {
@@ -52,9 +51,7 @@ class ReleasePlease {
 
   async init() {
     RP.registerChangelogNotes('default', ({ github, ...o }) => new ChangelogNotes(github, o))
-    RP.registerVersioningStrategy('default', o =>
-      o.prerelease ? new PrereleaseVersioningStrategy(o) : new DefaultVersioningStrategy(o),
-    )
+    RP.registerVersioningStrategy('default', o => new SemverVersioningStrategy(o))
     RP.registerPlugin(
       'node-workspace-format',
       ({ github, targetBranch, repositoryConfig, ...o }) =>

--- a/lib/release/semver-versioning-strategy.js
+++ b/lib/release/semver-versioning-strategy.js
@@ -6,16 +6,16 @@ const inc = (version, release, _preid) => {
   const implicitPreid = parsed.prerelease.length > 1 ? parsed.prerelease[0]?.toString() : undefined
   const preid = _preid || implicitPreid
   const next = new semver.SemVer(version).inc(release, preid)
+  if (!parsed.prerelease.length) {
+    return next.format()
+  }
   const isFreshMajor = parsed.minor === 0 && parsed.patch === 0
   const isFreshMinor = parsed.patch === 0
-  if (
-    parsed.prerelease.length &&
-    next.prerelease.length &&
-    ((release === 'premajor' && isFreshMajor) || (release === 'preminor' && isFreshMinor) || release === 'prepatch')
-  ) {
+  const shouldPrerelease = (release === 'premajor' && isFreshMajor) || (release === 'preminor' && isFreshMinor) || release === 'prepatch'
+  if (shouldPrerelease) {
     return semver.inc(version, 'prerelease', preid)
   }
-  return semver.inc(version, release, preid)
+  return next.format()
 }
 
 const parseCommits = commits => {

--- a/lib/release/semver-versioning-strategy.js
+++ b/lib/release/semver-versioning-strategy.js
@@ -1,0 +1,66 @@
+const semver = require('semver');
+const { Version } = require('release-please/build/src/version.js');
+
+const inc = (version, release, _preid) => {
+  const parsed = new semver.SemVer(version);
+  const implicitPreid =
+    parsed.prerelease.length > 1 ? parsed.prerelease[0]?.toString() : undefined;
+  const preid = _preid || implicitPreid;
+  const next = new semver.SemVer(version).inc(release, preid);
+  const isFreshMajor = parsed.minor === 0 && parsed.patch === 0;
+  const isFreshMinor = parsed.patch === 0;
+  if (
+    parsed.prerelease.length &&
+    next.prerelease.length &&
+    ((release === 'premajor' && isFreshMajor) ||
+      (release === 'preminor' && isFreshMinor) ||
+      release === 'prepatch')
+  ) {
+    return semver.inc(version, 'prerelease', preid);
+  }
+  return semver.inc(version, release, preid);
+};
+
+const parseCommits = (commits) => {
+  let release = 'patch';
+  for (const commit of commits) {
+    if (commit.breaking) {
+      release = 'major';
+      break;
+    } else if (['feat', 'feature'].includes(commit.type)) {
+      release = 'minor';
+    }
+  }
+  return release;
+};
+
+class SemverVersioningStrategy {
+  constructor(options) {
+    this.options = options;
+  }
+
+  determineReleaseType(_version, _commits) {
+    const options = this.options;
+    class Shell {
+      bump() {
+        return new SemverVersioningStrategy(options).bump(_version, _commits);
+      }
+    }
+    return new Shell();
+  }
+
+  bump(currentVersion, commits) {
+    const prerelease = this.options.prerelease;
+    const tag = this.options.prereleaseType;
+    const releaseType = parseCommits(commits);
+    const addPreIfNeeded = prerelease ? `pre${releaseType}` : releaseType;
+    const version = inc(currentVersion.toString(), addPreIfNeeded, tag);
+    /* istanbul ignore next */
+    if (!version) {  
+      throw new Error('Could not bump version');
+    }
+    return Version.parse(version);
+  }
+}
+
+module.exports = { SemverVersioningStrategy };

--- a/lib/release/semver-versioning-strategy.js
+++ b/lib/release/semver-versioning-strategy.js
@@ -11,7 +11,8 @@ const inc = (version, release, _preid) => {
   }
   const isFreshMajor = parsed.minor === 0 && parsed.patch === 0
   const isFreshMinor = parsed.patch === 0
-  const shouldPrerelease = (release === 'premajor' && isFreshMajor) || (release === 'preminor' && isFreshMinor) || release === 'prepatch'
+  const shouldPrerelease =
+    (release === 'premajor' && isFreshMajor) || (release === 'preminor' && isFreshMinor) || release === 'prepatch'
   if (shouldPrerelease) {
     return semver.inc(version, 'prerelease', preid)
   }
@@ -31,19 +32,25 @@ const parseCommits = commits => {
   return release
 }
 
+class SemverVersioningStrategyNested {
+  constructor(options, version, commits) {
+    this.options = options
+    this.commits = commits
+    this.version = version
+  }
+
+  bump() {
+    return new SemverVersioningStrategy(this.options).bump(this.version, this.commits)
+  }
+}
+
 class SemverVersioningStrategy {
   constructor(options) {
     this.options = options
   }
 
-  determineReleaseType(_version, _commits) {
-    const options = this.options
-    class Shell {
-      bump() {
-        return new SemverVersioningStrategy(options).bump(_version, _commits)
-      }
-    }
-    return new Shell()
+  determineReleaseType(version, commits) {
+    return new SemverVersioningStrategyNested(this.options, version, commits)
   }
 
   bump(currentVersion, commits) {

--- a/lib/release/semver-versioning-strategy.js
+++ b/lib/release/semver-versioning-strategy.js
@@ -1,66 +1,63 @@
-const semver = require('semver');
-const { Version } = require('release-please/build/src/version.js');
+const semver = require('semver')
+const { Version } = require('release-please/build/src/version.js')
 
 const inc = (version, release, _preid) => {
-  const parsed = new semver.SemVer(version);
-  const implicitPreid =
-    parsed.prerelease.length > 1 ? parsed.prerelease[0]?.toString() : undefined;
-  const preid = _preid || implicitPreid;
-  const next = new semver.SemVer(version).inc(release, preid);
-  const isFreshMajor = parsed.minor === 0 && parsed.patch === 0;
-  const isFreshMinor = parsed.patch === 0;
+  const parsed = new semver.SemVer(version)
+  const implicitPreid = parsed.prerelease.length > 1 ? parsed.prerelease[0]?.toString() : undefined
+  const preid = _preid || implicitPreid
+  const next = new semver.SemVer(version).inc(release, preid)
+  const isFreshMajor = parsed.minor === 0 && parsed.patch === 0
+  const isFreshMinor = parsed.patch === 0
   if (
     parsed.prerelease.length &&
     next.prerelease.length &&
-    ((release === 'premajor' && isFreshMajor) ||
-      (release === 'preminor' && isFreshMinor) ||
-      release === 'prepatch')
+    ((release === 'premajor' && isFreshMajor) || (release === 'preminor' && isFreshMinor) || release === 'prepatch')
   ) {
-    return semver.inc(version, 'prerelease', preid);
+    return semver.inc(version, 'prerelease', preid)
   }
-  return semver.inc(version, release, preid);
-};
+  return semver.inc(version, release, preid)
+}
 
-const parseCommits = (commits) => {
-  let release = 'patch';
+const parseCommits = commits => {
+  let release = 'patch'
   for (const commit of commits) {
     if (commit.breaking) {
-      release = 'major';
-      break;
+      release = 'major'
+      break
     } else if (['feat', 'feature'].includes(commit.type)) {
-      release = 'minor';
+      release = 'minor'
     }
   }
-  return release;
-};
+  return release
+}
 
 class SemverVersioningStrategy {
   constructor(options) {
-    this.options = options;
+    this.options = options
   }
 
   determineReleaseType(_version, _commits) {
-    const options = this.options;
+    const options = this.options
     class Shell {
       bump() {
-        return new SemverVersioningStrategy(options).bump(_version, _commits);
+        return new SemverVersioningStrategy(options).bump(_version, _commits)
       }
     }
-    return new Shell();
+    return new Shell()
   }
 
   bump(currentVersion, commits) {
-    const prerelease = this.options.prerelease;
-    const tag = this.options.prereleaseType;
-    const releaseType = parseCommits(commits);
-    const addPreIfNeeded = prerelease ? `pre${releaseType}` : releaseType;
-    const version = inc(currentVersion.toString(), addPreIfNeeded, tag);
+    const prerelease = this.options.prerelease
+    const tag = this.options.prereleaseType
+    const releaseType = parseCommits(commits)
+    const addPreIfNeeded = prerelease ? `pre${releaseType}` : releaseType
+    const version = inc(currentVersion.toString(), addPreIfNeeded, tag)
     /* istanbul ignore next */
-    if (!version) {  
-      throw new Error('Could not bump version');
+    if (!version) {
+      throw new Error('Could not bump version')
     }
-    return Version.parse(version);
+    return Version.parse(version)
   }
 }
 
-module.exports = { SemverVersioningStrategy };
+module.exports = { SemverVersioningStrategy }

--- a/test/release/version.js
+++ b/test/release/version.js
@@ -1,6 +1,6 @@
-const t = require('tap');
-const { Version } = require('release-please/build/src/version.js');
-const { SemverVersioningStrategy } = require('../../lib/release/semver-versioning-strategy');
+const t = require('tap')
+const { Version } = require('release-please/build/src/version.js')
+const { SemverVersioningStrategy } = require('../../lib/release/semver-versioning-strategy')
 
 const commit = {
   type: 'chore',
@@ -11,17 +11,17 @@ const commit = {
   bareMessage: '',
   sha: '',
   message: '',
-};
+}
 
-const g = (v) => ({ ...commit, ...v });
+const g = v => ({ ...commit, ...v })
 
 const COMMITS = {
   major: [{ type: 'feat' }, {}, {}, { breaking: true }].map(g),
   minor: [{}, {}, { type: 'feat' }].map(g),
   patch: [{}, { type: 'chore' }, { type: 'fix' }].map(g),
-};
+}
 
-const throws = "THROWS"
+const throws = 'THROWS'
 
 const checks = [
   // Normal releases
@@ -67,30 +67,24 @@ const checks = [
   ['2.0.0-rc.1', 'major', false, undefined, '2.0.0'],
   ['2.0.0-0', 'major', false, undefined, '2.0.0'],
   ['xxxx', 'major', false, undefined, throws],
-];
+]
 
-t.test('SemverVersioningStrategy', async (t) => {
+t.test('SemverVersioningStrategy', async t => {
   for (const [version, commits, prerelease, prereleaseType, expected] of checks) {
-    const name = [version, commits, prerelease, prereleaseType, expected];
-    const id = name.map((v) => (typeof v === 'undefined' ? 'undefined' : v)).join(',');    
+    const name = [version, commits, prerelease, prereleaseType, expected]
+    const id = name.map(v => (typeof v === 'undefined' ? 'undefined' : v)).join(',')
     const instance = new SemverVersioningStrategy({ prerelease, prereleaseType })
-    
+
     if (expected === throws) {
-      t.throws(() => instance.bump(Version.parse(version), COMMITS[commits]), id);
-      continue;
+      t.throws(() => instance.bump(Version.parse(version), COMMITS[commits]), id)
+      continue
     }
 
-    const bump = instance.bump(
-      Version.parse(version),
-      COMMITS[commits]
-    );
+    const bump = instance.bump(Version.parse(version), COMMITS[commits])
 
-    const determine = instance.determineReleaseType(
-      Version.parse(version),
-      COMMITS[commits]
-    );
+    const determine = instance.determineReleaseType(Version.parse(version), COMMITS[commits])
 
-    t.equal(bump.toString(), expected, id);
-    t.equal(determine.bump().toString(), expected, id);
+    t.equal(bump.toString(), expected, id)
+    t.equal(determine.bump().toString(), expected, id)
   }
-});
+})

--- a/test/release/version.js
+++ b/test/release/version.js
@@ -1,0 +1,96 @@
+const t = require('tap');
+const { Version } = require('release-please/build/src/version.js');
+const { SemverVersioningStrategy } = require('../../lib/release/semver-versioning-strategy');
+
+const commit = {
+  type: 'chore',
+  breaking: false,
+  notes: [],
+  references: [],
+  scope: '',
+  bareMessage: '',
+  sha: '',
+  message: '',
+};
+
+const g = (v) => ({ ...commit, ...v });
+
+const COMMITS = {
+  major: [{ type: 'feat' }, {}, {}, { breaking: true }].map(g),
+  minor: [{}, {}, { type: 'feat' }].map(g),
+  patch: [{}, { type: 'chore' }, { type: 'fix' }].map(g),
+};
+
+const throws = "THROWS"
+
+const checks = [
+  // Normal releases
+  ['2.0.0', 'major', false, undefined, '3.0.0'],
+  ['2.0.0', 'minor', false, undefined, '2.1.0'],
+  ['2.0.0', 'patch', false, undefined, '2.0.1'],
+  // premajor -> normal
+  ['2.0.0-pre.1', 'major', false, undefined, '2.0.0'],
+  ['2.0.0-pre.5', 'minor', false, undefined, '2.0.0'],
+  ['2.0.0-pre.4', 'patch', false, undefined, '2.0.0'],
+  // preminor -> normal
+  ['2.1.0-pre.1', 'major', false, undefined, '3.0.0'],
+  ['2.1.0-pre.5', 'minor', false, undefined, '2.1.0'],
+  ['2.1.0-pre.4', 'patch', false, undefined, '2.1.0'],
+  // prepatch -> normal
+  ['2.0.1-pre.1', 'major', false, undefined, '3.0.0'],
+  ['2.0.1-pre.5', 'minor', false, undefined, '2.1.0'],
+  ['2.0.1-pre.4', 'patch', false, undefined, '2.0.1'],
+  // Prereleases
+  ['2.0.0', 'major', true, 'pre', '3.0.0-pre.0'],
+  ['2.0.0', 'minor', true, 'pre', '2.1.0-pre.0'],
+  ['2.0.0', 'patch', true, 'pre', '2.0.1-pre.0'],
+  // premajor - prereleases
+  ['2.0.0-pre.1', 'major', true, undefined, '2.0.0-pre.2'],
+  ['2.0.0-pre.1', 'minor', true, undefined, '2.0.0-pre.2'],
+  ['2.0.0-pre.1', 'patch', true, undefined, '2.0.0-pre.2'],
+  // preminor - prereleases
+  ['2.1.0-pre.1', 'major', true, undefined, '3.0.0-pre.0'],
+  ['2.1.0-pre.1', 'minor', true, undefined, '2.1.0-pre.2'],
+  ['2.1.0-pre.1', 'patch', true, undefined, '2.1.0-pre.2'],
+  // prepatch - prereleases
+  ['2.0.1-pre.1', 'major', true, undefined, '3.0.0-pre.0'],
+  ['2.0.1-pre.1', 'minor', true, undefined, '2.1.0-pre.0'],
+  ['2.0.1-pre.1', 'patch', true, undefined, '2.0.1-pre.2'],
+  // different prerelease identifiers
+  ['2.0.0-beta.1', 'major', true, undefined, '2.0.0-beta.2'],
+  ['2.0.0-alpha.1', 'major', true, undefined, '2.0.0-alpha.2'],
+  ['2.0.0-rc.1', 'major', true, undefined, '2.0.0-rc.2'],
+  ['2.0.0-0', 'major', true, undefined, '2.0.0-1'],
+  // leaves prerelease
+  ['2.0.0-beta.1', 'major', false, undefined, '2.0.0'],
+  ['2.0.0-alpha.1', 'major', false, undefined, '2.0.0'],
+  ['2.0.0-rc.1', 'major', false, undefined, '2.0.0'],
+  ['2.0.0-0', 'major', false, undefined, '2.0.0'],
+  ['xxxx', 'major', false, undefined, throws],
+];
+
+t.test('SemverVersioningStrategy', async (t) => {
+  for (const [version, commits, prerelease, prereleaseType, expected] of checks) {
+    const name = [version, commits, prerelease, prereleaseType, expected];
+    const id = name.map((v) => (typeof v === 'undefined' ? 'undefined' : v)).join(',');    
+    const instance = new SemverVersioningStrategy({ prerelease, prereleaseType })
+    
+    if (expected === throws) {
+      t.throws(() => instance.bump(Version.parse(version), COMMITS[commits]), id);
+      continue;
+    }
+
+    const bump = instance.bump(
+      Version.parse(version),
+      COMMITS[commits]
+    );
+
+    const determine = instance.determineReleaseType(
+      Version.parse(version),
+      COMMITS[commits]
+    );
+
+    t.equal(bump.toString(), expected, id);
+    t.equal(determine.bump().toString(), expected, id);
+  }
+});


### PR DESCRIPTION
`prereleases` do not work in release-please, i'm seeing the inability to get a repo into or out of `prerelease` mode, (where the packages have tags in the versions ie. `-pre-0` at the end).

* I was unable to get a repo *into* prerelease using the latest version of release-please on my personal project `reggi/packages`.
* And the `npm/cli` has been stuck in prerelease mode. It was able to get itself into prerelease because of the wrapper around release-please we have in this repo. (trail: [npm/cli workflow](https://github.com/npm/cli/blob/latest/.github/workflows/release.yml#L54), [Strategy Turnery](https://github.com/npm/template-oss/blob/abdc9398f47d4761d589617235bee0fdb4827128/lib/release/release-please.js#L56))

I do not believe release please has this `options.prerelease ternary anymore` here's the [mapping of what versioning-strategy is uses](https://github.com/googleapis/release-please/blob/3e807972fc8d1a348cd45e32d933ada4d25d4a28/src/factories/versioning-strategy-factory.ts#L40-L47).

And even if it did choose to use `PrereleaseVersioningStrategy` or `DefaultVersioningStrategy` neither of these strategies have the ability to leave a prerelease. Because they always [add the current `prereleaseType` or `prereleaseType` from the config from the existing version](https://github.com/googleapis/release-please/blob/3e807972fc8d1a348cd45e32d933ada4d25d4a28/src/versioning-strategies/prerelease.ts#L116-L135). Neither of these classes even have access to the `options.prerelease` boolean.

I created a fork of release-please which would deprecate the need for this PR, https://github.com/reggi/release-please with the typescirpt / esm alternatives to the files included in this PR:
* https://github.com/reggi/release-please/blob/main/src/versioning-strategies/semver.ts
* https://github.com/reggi/release-please/blob/main/test/versioning-strategies/semver.ts

This is added as a new versioning-strategy `semver`. To note the property currently documented as `versioning-strategy` in the docs is not working, and is currently `versioning`. [I opened a PR to fix the json schema for the config](https://github.com/googleapis/release-please/pull/2450), but now we know it's a bug i'll leave that discussion open there.

So `"versioning-strategy": "semver"` would be ignored and you'd need `"versioning": "semver"`, again not relevant to *this* PR but another quirk to note.

This PR replaces both strategies with a new `SemverVersioningStrategy` which is always used, and has prerelease-aware replacement for `semver.inc`

* Given the existing functionality for `semver.inc`, when incrementing to `preminor` with `2.1.0-pre.1` it bumps the minor `2.2.0-pre.0` which is incorrect. 
* The `inc` function included in this pr takes `2.1.0-pre.1` and sees that `patch` is `0` and will assume a bump has already taken place because it's in prerelease, and will only increment the tag number (known in semver as `identifierBase` or `n`) to `2.1.0-pre.2`.

We will most likely also have extended conversations about adding this new prerelease-aware functionality to `semver.inc` in some way so other projects such as release-please can properly implement prereleases.