### PR TITLE
chore: versioning strategy

### DIFF
--- a/lib/release/semver-versioning-strategy.js
+++ b/lib/release/semver-versioning-strategy.js
@@ -1,21 +1,23 @@
 const semver = require('semver')
 const { Version } = require('release-please/build/src/version.js')
 
-const inc = (version, release, _preid) => {
+const inc = (version, releaseType, prereleaseMode, preid) => {
   const parsed = new semver.SemVer(version)
   const implicitPreid = parsed.prerelease.length > 1 ? parsed.prerelease[0]?.toString() : undefined
-  const preid = _preid || implicitPreid
-  const next = new semver.SemVer(version).inc(release, preid)
-  if (!parsed.prerelease.length) {
-    return next.format()
-  }
-  const isFreshMajor = parsed.minor === 0 && parsed.patch === 0
-  const isFreshMinor = parsed.patch === 0
-  const shouldPrerelease =
-    (release === 'premajor' && isFreshMajor) || (release === 'preminor' && isFreshMinor) || release === 'prepatch'
-  if (shouldPrerelease) {
-    return semver.inc(version, 'prerelease', preid)
-  }
+  const nextPreid = preid || implicitPreid
+
+  const isMajor = parsed.minor === 0 && parsed.patch === 0
+  const isMinor = parsed.patch === 0
+  const isPrerelease = parsed.prerelease.length > 0
+
+  const nextReleaseType =
+    !prereleaseMode ? releaseType :                          // normal release
+      !isPrerelease ? 'pre' + releaseType :                  // first prerelease
+        !isMajor && releaseType === 'major' ? 'premajor' :   // minor or patch prerelease and major coming
+          !isMinor && releaseType === 'minor' ? 'preminor' : // patch prerelease and minor coming
+            'prerelease'                                     // next prerelease
+
+  const next = new semver.SemVer(version).inc(nextReleaseType, nextPreid)
   return next.format()
 }
 
@@ -57,8 +59,7 @@ class SemverVersioningStrategy {
     const prerelease = this.options.prerelease
     const tag = this.options.prereleaseType
     const releaseType = parseCommits(commits)
-    const addPreIfNeeded = prerelease ? `pre${releaseType}` : releaseType
-    const version = inc(currentVersion.toString(), addPreIfNeeded, tag)
+    const version = inc(currentVersion.toString(), releaseType, prerelease, tag)
     /* istanbul ignore next */
     if (!version) {
       throw new Error('Could not bump version')


### PR DESCRIPTION
This consolidates the logic for determining the release type used to increase the version. Only a single `inc` call is made.

It matches the description I gave in https://github.com/npm/node-semver/issues/751 and passes all tests.