### PR TITLE
deps: tap@21.0.1

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -87,20 +87,17 @@ jobs:
             os: windows-latest
             shell: cmd
         node-version:
-          - 18.17.0
-          - 18.x
-          - 20.5.0
+          - 20.17.0
           - 20.x
+          - 22.9.0
           - 22.x
         exclude:
           - platform: { name: macOS, os: macos-13, shell: bash }
-            node-version: 18.17.0
-          - platform: { name: macOS, os: macos-13, shell: bash }
-            node-version: 18.x
-          - platform: { name: macOS, os: macos-13, shell: bash }
-            node-version: 20.5.0
+            node-version: 20.17.0
           - platform: { name: macOS, os: macos-13, shell: bash }
             node-version: 20.x
+          - platform: { name: macOS, os: macos-13, shell: bash }
+            node-version: 22.9.0
           - platform: { name: macOS, os: macos-13, shell: bash }
             node-version: 22.x
     runs-on: ${{ matrix.platform.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,20 +68,17 @@ jobs:
             os: windows-latest
             shell: cmd
         node-version:
-          - 18.17.0
-          - 18.x
-          - 20.5.0
+          - 20.17.0
           - 20.x
+          - 22.9.0
           - 22.x
         exclude:
           - platform: { name: macOS, os: macos-13, shell: bash }
-            node-version: 18.17.0
-          - platform: { name: macOS, os: macos-13, shell: bash }
-            node-version: 18.x
-          - platform: { name: macOS, os: macos-13, shell: bash }
-            node-version: 20.5.0
+            node-version: 20.17.0
           - platform: { name: macOS, os: macos-13, shell: bash }
             node-version: 20.x
+          - platform: { name: macOS, os: macos-13, shell: bash }
+            node-version: 22.9.0
           - platform: { name: macOS, os: macos-13, shell: bash }
             node-version: 22.x
     runs-on: ${{ matrix.platform.os }}

--- a/lib/content/package-json.hbs
+++ b/lib/content/package-json.hbs
@@ -50,6 +50,7 @@
     {{/if}}
     "test-ignore": {{{ del }}},
     {{else}}
+    "exclude": {{{ del }}},
     {{#if workspacePaths}}
       "exclude": {{#if tap18}}[
         "{{ join workspaceGlobs "," }}"

--- a/lib/content/package-json.hbs
+++ b/lib/content/package-json.hbs
@@ -40,11 +40,11 @@
   },
   "templateVersion": {{{ del }}},
   "standard": {{{ del }}},
-  "nyc": {{#if tapOver17}}{
+  "nyc": {{#if tap18}}{
     "exclude": {{{ json workspaceGlobs }}}
   }{{else}}{{{ del }}}{{/if}},
   "tap": {
-    {{#if tapOver17}}
+    {{#if tap18}}
     {{#if workspaceGlobs}}
     "exclude": {{{ json workspaceGlobs }}},
     {{/if}}
@@ -68,8 +68,8 @@
     ],
     {{/if}}
     {{/if}}
-    "show-full-coverage": {{#if tapOver17}}true{{else}}{{{ del }}}{{/if}},
-    "nyc-arg": {{#if tapOver17}}{{{ del }}}{{else}}[
+    "show-full-coverage": {{#if tap18}}true{{else}}{{{ del }}}{{/if}},
+    "nyc-arg": {{#if tap18}}{{{ del }}}{{else}}[
       {{#each workspaceGlobs}}
       "--exclude",
       "{{ . }}",

--- a/lib/content/package-json.hbs
+++ b/lib/content/package-json.hbs
@@ -40,12 +40,22 @@
   },
   "templateVersion": {{{ del }}},
   "standard": {{{ del }}},
+  "nyc": {{#if tapOver17}}{
+    "exclude": {{{ json workspaceGlobs }}}
+  }{{else}}{{{ del }}}{{/if}},
   "tap": {
+    {{#if tapOver17}}
+    {{#if workspaceGlobs}}
+    "exclude": {{{ json workspaceGlobs }}},
+    {{/if}}
+    "test-ignore": {{{ del }}},
+    {{else}}
     {{#if workspacePaths}}
       "exclude": {{#if tap18}}[
         "{{ join workspaceGlobs "," }}"
         ]{{else }}{{{ del }}}{{/if}},
       "test-ignore": {{#if tap18}}{{{ del }}}{{else}}"^({{ join workspacePaths "|" }})/"{{/if}},
+    {{/if}}
     {{/if}}
     {{#if typescript}}
     {{#if tap16}}
@@ -57,7 +67,8 @@
     ],
     {{/if}}
     {{/if}}
-    "nyc-arg": {{#if tap18}}{{{ del }}}{{else}}[
+    "show-full-coverage": {{#if tapOver17}}true{{else}}{{{ del }}}{{/if}},
+    "nyc-arg": {{#if tapOver17}}{{{ del }}}{{else}}[
       {{#each workspaceGlobs}}
       "--exclude",
       "{{ . }}",

--- a/lib/release/node-workspace-format.js
+++ b/lib/release/node-workspace-format.js
@@ -5,7 +5,8 @@ const { TagName } = require('release-please/build/src/util/tag-name.js')
 const { ROOT_PROJECT_PATH } = require('release-please/build/src/manifest.js')
 const { DEPS, link, wrapSpecs, list } = require('./util.js')
 
-/* istanbul ignore next: TODO fix flaky tests and enable coverage */
+/* TODO fix flaky tests and enable coverage */
+/* c8 ignore start */
 module.exports = class extends ManifestPlugin {
   static WORKSPACE_MESSAGE = (name, version) => `${DEPS}(workspace): ${name}@${version}`
 
@@ -95,3 +96,4 @@ module.exports = class extends ManifestPlugin {
     }
   }
 }
+/* c8 ignore end */

--- a/lib/release/release-manager.js
+++ b/lib/release/release-manager.js
@@ -165,13 +165,14 @@ class ReleaseManager {
       // If the url fails with anything but a 404 we want the process to blow
       // up because that means something is very wrong. This is a rare edge
       // case that isn't worth testing.
-      /* istanbul ignore else */
+
       if (r.statusCode === 200) {
         this.#info('Found release process from wiki')
         return r.body.text()
       } else if (r.statusCode === 404) {
         this.#info('No release process found in wiki, falling back to default process')
         return this.#getReleaseSteps()
+        /* c8 ignore next 3 */
       } else {
         throw new Error(`Release process fetch failed with status: ${r.statusCode}`)
       }

--- a/lib/release/release-please.js
+++ b/lib/release/release-please.js
@@ -9,7 +9,8 @@ const NodeWorkspaceFormat = require('./node-workspace-format.js')
 const { getPublishTag, noop } = require('./util.js')
 const { SemverVersioningStrategy } = require('./semver-versioning-strategy.js')
 
-/* istanbul ignore next: TODO fix flaky tests and enable coverage */
+/* TODO fix flaky tests and enable coverage */
+/* c8 ignore start */
 class ReleasePlease {
   #token
   #owner
@@ -163,5 +164,6 @@ class ReleasePlease {
     return releases.length ? releases : null
   }
 }
+/* c8 ignore end */
 
 module.exports = ReleasePlease

--- a/lib/release/semver-versioning-strategy.js
+++ b/lib/release/semver-versioning-strategy.js
@@ -59,10 +59,11 @@ class SemverVersioningStrategy {
     const releaseType = parseCommits(commits)
     const addPreIfNeeded = prerelease ? `pre${releaseType}` : releaseType
     const version = inc(currentVersion.toString(), addPreIfNeeded, tag)
-    /* istanbul ignore next */
+    /* c8 ignore start */
     if (!version) {
       throw new Error('Could not bump version')
     }
+    /* c8 ignore stop */
     return Version.parse(version)
   }
 }

--- a/lib/util/import-or-require.js
+++ b/lib/util/import-or-require.js
@@ -17,10 +17,12 @@ const importOrRequire = async path => {
   } catch {
     try {
       content = await import(pathToFileURL(path)).then(r => r.default)
+      /* c8 ignore start */
     } catch {
       // its ok if this fails since the content dir might only be to provide
       // other files. the index.js is optional
     }
+    /* c8 ignore end */
   }
   importOrRequireCache.set(path, content)
   return content

--- a/lib/util/import-or-require.js
+++ b/lib/util/import-or-require.js
@@ -15,7 +15,6 @@ const importOrRequire = async path => {
   try {
     content = require(path)
     // this is for node 22+
-    // istanbul ignore next
     /* c8 ignore start */
     if (content.__esModule) {
       return content.default

--- a/package.json
+++ b/package.json
@@ -73,19 +73,16 @@
     "eslint-config-prettier": "^9.1.0",
     "nock": "^13.3.8",
     "prettier": "^3.2.5",
-    "tap": "^16.0.0"
+    "tap": "^19.0.2"
   },
   "tap": {
     "timeout": 600,
-    "nyc-arg": [
-      "--exclude",
-      "workspace/test-workspace/**",
-      "--exclude",
-      "tap-snapshots/**"
-    ],
-    "test-ignore": "^(workspace/test-workspace)/",
     "node-arg": [
       "--no-experimental-fetch"
+    ],
+    "show-full-coverage": true,
+    "exclude": [
+      "workspace/test-workspace/**"
     ]
   },
   "templateOSS": {
@@ -98,5 +95,10 @@
   },
   "workspaces": [
     "workspace/test-workspace"
-  ]
+  ],
+  "nyc": {
+    "exclude": [
+      "workspace/test-workspace/**"
+    ]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -80,10 +80,10 @@
     "node-arg": [
       "--no-experimental-fetch"
     ],
-    "show-full-coverage": true,
     "exclude": [
       "workspace/test-workspace/**"
-    ]
+    ],
+    "show-full-coverage": true
   },
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "eslint-config-prettier": "^9.1.0",
     "nock": "^13.3.8",
     "prettier": "^3.2.5",
-    "tap": "^19.0.2"
+    "tap": "^21.0.1"
   },
   "tap": {
     "timeout": 600,

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "prettier": true
   },
   "engines": {
-    "node": "^18.17.0 || >=20.5.0"
+    "node": "^20.17.0 || >=22.9.0"
   },
   "workspaces": [
     "workspace/test-workspace"

--- a/tap-snapshots/test/apply/files-snapshots.js.test.cjs
+++ b/tap-snapshots/test/apply/files-snapshots.js.test.cjs
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/apply/files-snapshots.js TAP private workspace > expect resolving Promise 1`] = `
+exports[`test/apply/files-snapshots.js > TAP > private workspace > promise must resolve to match snapshot 1`] = `
 .commitlintrc.js
 .eslintrc.js
 .github/actions/create-check/action.yml
@@ -42,7 +42,7 @@ workspaces/b/.gitignore
 workspaces/b/package.json
 `
 
-exports[`test/apply/files-snapshots.js TAP turn off add/rm types > expect resolving Promise 1`] = `
+exports[`test/apply/files-snapshots.js > TAP > turn off add/rm types > promise must resolve to match snapshot 1`] = `
 .commitlintrc.js
 .github/actions/create-check/action.yml
 .github/actions/install-latest-npm/action.yml
@@ -65,7 +65,7 @@ package.json
 release-please-config.json
 `
 
-exports[`test/apply/files-snapshots.js TAP turn off module > expect resolving Promise 1`] = `
+exports[`test/apply/files-snapshots.js > TAP > turn off module > promise must resolve to match snapshot 1`] = `
 .commitlintrc.js
 .github/actions/create-check/action.yml
 .github/actions/install-latest-npm/action.yml
@@ -88,7 +88,7 @@ package.json
 release-please-config.json
 `
 
-exports[`test/apply/files-snapshots.js TAP turn off repo > expect resolving Promise 1`] = `
+exports[`test/apply/files-snapshots.js > TAP > turn off repo > promise must resolve to match snapshot 1`] = `
 .eslintrc.js
 .gitignore
 .npmrc
@@ -98,11 +98,11 @@ package.json
 SECURITY.md
 `
 
-exports[`test/apply/files-snapshots.js TAP turn off root > expect resolving Promise 1`] = `
+exports[`test/apply/files-snapshots.js > TAP > turn off root > promise must resolve to match snapshot 1`] = `
 package.json
 `
 
-exports[`test/apply/files-snapshots.js TAP turn off specific files > expect resolving Promise 1`] = `
+exports[`test/apply/files-snapshots.js > TAP > turn off specific files > promise must resolve to match snapshot 1`] = `
 .eslintrc.yml
 .github/actions/create-check/action.yml
 .github/actions/install-latest-npm/action.yml
@@ -131,7 +131,7 @@ release-please-config.json
 SECURITY.md
 `
 
-exports[`test/apply/files-snapshots.js TAP workspaces > expect resolving Promise 1`] = `
+exports[`test/apply/files-snapshots.js > TAP > workspaces > promise must resolve to match snapshot 1`] = `
 .github/actions/create-check/action.yml
 .github/actions/install-latest-npm/action.yml
 .github/dependabot.yml
@@ -158,7 +158,7 @@ workspaces/d/.gitignore
 workspaces/d/package.json
 `
 
-exports[`test/apply/files-snapshots.js TAP workspaces only (like npm/cli) > expect resolving Promise 1`] = `
+exports[`test/apply/files-snapshots.js > TAP > workspaces only (like npm/cli) > promise must resolve to match snapshot 1`] = `
 .github/actions/create-check/action.yml
 .github/actions/install-latest-npm/action.yml
 .github/dependabot.yml
@@ -182,7 +182,7 @@ workspaces/b/.gitignore
 workspaces/b/package.json
 `
 
-exports[`test/apply/files-snapshots.js TAP workspaces with relative content path > expect resolving Promise 1`] = `
+exports[`test/apply/files-snapshots.js > TAP > workspaces with relative content path > promise must resolve to match snapshot 1`] = `
 content_dir/index.js
 content_dir2/index.js
 package.json

--- a/tap-snapshots/test/apply/source-snapshots.js.test.cjs
+++ b/tap-snapshots/test/apply/source-snapshots.js.test.cjs
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/apply/source-snapshots.js TAP root only > expect resolving Promise 1`] = `
+exports[`test/apply/source-snapshots.js > TAP > root only > promise must resolve to match snapshot 1`] = `
 .commitlintrc.js
 ========================================
 /* This file is automatically added by @npmcli/template-oss. Do not edit. */
@@ -1426,7 +1426,7 @@ If the vulnerability you have found is [in scope for the GitHub Bug Bounty Progr
 Thanks for helping make GitHub safe for everyone.
 `
 
-exports[`test/apply/source-snapshots.js TAP with content path > expect resolving Promise 1`] = `
+exports[`test/apply/source-snapshots.js > TAP > with content path > promise must resolve to match snapshot 1`] = `
 content_dir/index.js
 ========================================
 module.exports={}
@@ -1444,7 +1444,7 @@ package.json
 }
 `
 
-exports[`test/apply/source-snapshots.js TAP with workspaces > expect resolving Promise 1`] = `
+exports[`test/apply/source-snapshots.js > TAP > with workspaces > promise must resolve to match snapshot 1`] = `
 .commitlintrc.js
 ========================================
 /* This file is automatically added by @npmcli/template-oss. Do not edit. */
@@ -3272,7 +3272,7 @@ workspaces/b/package.json
 }
 `
 
-exports[`test/apply/source-snapshots.js TAP workspaces only > expect resolving Promise 1`] = `
+exports[`test/apply/source-snapshots.js > TAP > workspaces only > promise must resolve to match snapshot 1`] = `
 .github/actions/create-check/action.yml
 ========================================
 # This file is automatically added by @npmcli/template-oss. Do not edit.
@@ -4636,7 +4636,7 @@ workspaces/b/package.json
 }
 `
 
-exports[`test/apply/source-snapshots.js TAP workspaces with nested content path > expect resolving Promise 1`] = `
+exports[`test/apply/source-snapshots.js > TAP > workspaces with nested content path > promise must resolve to match snapshot 1`] = `
 content_dir/index.js
 ========================================
 module.exports={}

--- a/tap-snapshots/test/bin/check.js.test.cjs
+++ b/tap-snapshots/test/bin/check.js.test.cjs
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/bin/check.js TAP problems > must match snapshot 1`] = `
+exports[`test/bin/check.js > TAP > problems > must match snapshot 1`] = `
 
 Some problems were detected:
 

--- a/tap-snapshots/test/check/diff-snapshots.js.test.cjs
+++ b/tap-snapshots/test/check/diff-snapshots.js.test.cjs
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/check/diff-snapshots.js TAP different headers > expect resolving Promise 1`] = `
+exports[`test/check/diff-snapshots.js > TAP > different headers > promise must resolve to match snapshot 1`] = `
 Some problems were detected:
 
 -------------------------------------------------------------------
@@ -21,7 +21,7 @@ To correct it: npx template-oss-apply --force
 -------------------------------------------------------------------
 `
 
-exports[`test/check/diff-snapshots.js TAP json delete > expect resolving Promise 1`] = `
+exports[`test/check/diff-snapshots.js > TAP > json delete > promise must resolve to match snapshot 1`] = `
 Some problems were detected:
 
 -------------------------------------------------------------------
@@ -39,7 +39,7 @@ To correct it: npx template-oss-apply --force
 -------------------------------------------------------------------
 `
 
-exports[`test/check/diff-snapshots.js TAP json merge > initial check 1`] = `
+exports[`test/check/diff-snapshots.js > TAP > json merge > initial check 1`] = `
 Some problems were detected:
 
 -------------------------------------------------------------------
@@ -56,7 +56,7 @@ To correct it: npx template-oss-apply --force
 -------------------------------------------------------------------
 `
 
-exports[`test/check/diff-snapshots.js TAP json overwrite > expect resolving Promise 1`] = `
+exports[`test/check/diff-snapshots.js > TAP > json overwrite > promise must resolve to match snapshot 1`] = `
 Some problems were detected:
 
 -------------------------------------------------------------------
@@ -73,7 +73,7 @@ To correct it: npx template-oss-apply --force
 -------------------------------------------------------------------
 `
 
-exports[`test/check/diff-snapshots.js TAP unknown file type > expect resolving Promise 1`] = `
+exports[`test/check/diff-snapshots.js > TAP > unknown file type > promise must resolve to match snapshot 1`] = `
 Some problems were detected:
 
 -------------------------------------------------------------------
@@ -87,7 +87,7 @@ To correct it: npx template-oss-apply --force
 -------------------------------------------------------------------
 `
 
-exports[`test/check/diff-snapshots.js TAP update and remove errors > expect resolving Promise 1`] = `
+exports[`test/check/diff-snapshots.js > TAP > update and remove errors > promise must resolve to match snapshot 1`] = `
 Some problems were detected:
 
 -------------------------------------------------------------------
@@ -97,7 +97,7 @@ The repo file audit.yml needs to be updated:
   .github/workflows/audit.yml
   ========================================
   [@npmcli/template-oss ERROR] There was an erroring getting the target file
-  [@npmcli/template-oss ERROR] Error: {{ROOT}}/test/check/tap-testdir-diff-snapshots-update-and-remove-errors/.github/workflows/audit.yml
+  [@npmcli/template-oss ERROR] Error: {{ROOT}}/.tap/fixtures/test-check-diff-snapshots.js-update-and-remove-errors/.github/workflows/audit.yml
   
   YAMLParseError: Implicit keys need to be on a single line at line 42, column 1:
   
@@ -222,7 +222,7 @@ To correct it: npx template-oss-apply --force
 -------------------------------------------------------------------
 `
 
-exports[`test/check/diff-snapshots.js TAP will diff json > expect resolving Promise 1`] = `
+exports[`test/check/diff-snapshots.js > TAP > will diff json > promise must resolve to match snapshot 1`] = `
 Some problems were detected:
 
 -------------------------------------------------------------------

--- a/tap-snapshots/test/check/snapshots.js.test.cjs
+++ b/tap-snapshots/test/check/snapshots.js.test.cjs
@@ -258,7 +258,7 @@ To correct it: move files to not match one of the following patterns:
 -------------------------------------------------------------------
 `
 
-exports[`test/check/snapshots.js > TAP > not ok without required > promise must resolve to match snapshot 1`] = `
+exports[`test/check/snapshots.js > TAP > not good without required > promise must resolve to match snapshot 1`] = `
 Some problems were detected:
 
 -------------------------------------------------------------------

--- a/tap-snapshots/test/check/snapshots.js.test.cjs
+++ b/tap-snapshots/test/check/snapshots.js.test.cjs
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/check/snapshots.js TAP changelog > expect resolving Promise 1`] = `
+exports[`test/check/snapshots.js > TAP > changelog > promise must resolve to match snapshot 1`] = `
 Some problems were detected:
 
 -------------------------------------------------------------------
@@ -22,7 +22,7 @@ To correct it: reformat the changelog to have the correct heading
 -------------------------------------------------------------------
 `
 
-exports[`test/check/snapshots.js TAP check empty dir > expect resolving Promise 1`] = `
+exports[`test/check/snapshots.js > TAP > check empty dir > promise must resolve to match snapshot 1`] = `
 Some problems were detected:
 
 -------------------------------------------------------------------
@@ -111,7 +111,7 @@ To correct it: npm rm @npmcli/template-oss @npmcli/eslint-config tap && npm i @n
 -------------------------------------------------------------------
 `
 
-exports[`test/check/snapshots.js TAP gitignore > expect resolving Promise 1`] = `
+exports[`test/check/snapshots.js > TAP > gitignore > promise must resolve to match snapshot 1`] = `
 Some problems were detected:
 
 -------------------------------------------------------------------
@@ -156,7 +156,7 @@ To correct it: move files to not match one of the following patterns:
 -------------------------------------------------------------------
 `
 
-exports[`test/check/snapshots.js TAP gitignore with workspaces workspace > expect resolving Promise 1`] = `
+exports[`test/check/snapshots.js > TAP > gitignore with workspaces workspace > promise must resolve to match snapshot 1`] = `
 Some problems were detected:
 
 -------------------------------------------------------------------
@@ -258,7 +258,7 @@ To correct it: move files to not match one of the following patterns:
 -------------------------------------------------------------------
 `
 
-exports[`test/check/snapshots.js TAP not ok without required > expect resolving Promise 1`] = `
+exports[`test/check/snapshots.js > TAP > not ok without required > promise must resolve to match snapshot 1`] = `
 Some problems were detected:
 
 -------------------------------------------------------------------
@@ -274,7 +274,7 @@ To correct it: npm rm @npmcli/template-oss @npmcli/eslint-config tap && npm i @n
 -------------------------------------------------------------------
 `
 
-exports[`test/check/snapshots.js TAP unwanted > expect resolving Promise 1`] = `
+exports[`test/check/snapshots.js > TAP > unwanted > promise must resolve to match snapshot 1`] = `
 Some problems were detected:
 
 -------------------------------------------------------------------
@@ -288,7 +288,7 @@ To correct it: npm rm eslint
 -------------------------------------------------------------------
 `
 
-exports[`test/check/snapshots.js TAP workspaces with empty dir > expect resolving Promise 1`] = `
+exports[`test/check/snapshots.js > TAP > workspaces with empty dir > promise must resolve to match snapshot 1`] = `
 Some problems were detected:
 
 -------------------------------------------------------------------

--- a/tap-snapshots/test/release/release-manager-mock-release-manager.js.test.cjs
+++ b/tap-snapshots/test/release/release-manager-mock-release-manager.js.test.cjs
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/release/release-manager.js TAP mock release manager > must match snapshot 1`] = `
+exports[`test/release/release-manager.js > TAP > mock release manager > must match snapshot 1`] = `
 ### Release Checklist for v4.0.5
 
 - [ ] 1. Checkout the release branch and test

--- a/tap-snapshots/test/release/release-manager-npm-cli.js.test.cjs
+++ b/tap-snapshots/test/release/release-manager-npm-cli.js.test.cjs
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/release/release-manager.js TAP npm/cli > must match snapshot 1`] = `
+exports[`test/release/release-manager.js > TAP > npm/cli > must match snapshot 1`] = `
 ### Release Checklist for v10.2.5
 
 - [ ] 1. Checkout the release branch

--- a/tap-snapshots/test/release/release-manager-prerelease.js.test.cjs
+++ b/tap-snapshots/test/release/release-manager-prerelease.js.test.cjs
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/release/release-manager.js TAP prerelease > must match snapshot 1`] = `
+exports[`test/release/release-manager.js > TAP > prerelease > must match snapshot 1`] = `
 ### Release Checklist for v10.0.0-pre.0
 
 - [ ] 1. Checkout the release branch

--- a/tap-snapshots/test/release/release-manager-publish-and-lockfile.js.test.cjs
+++ b/tap-snapshots/test/release/release-manager-publish-and-lockfile.js.test.cjs
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/release/release-manager.js TAP publish and lockfile > must match snapshot 1`] = `
+exports[`test/release/release-manager.js > TAP > publish and lockfile > must match snapshot 1`] = `
 ### Release Checklist for v7.5.4
 
 - [ ] 1. Approve this PR

--- a/tap-snapshots/test/release/release-manager-single-release.js.test.cjs
+++ b/tap-snapshots/test/release/release-manager-single-release.js.test.cjs
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/release/release-manager.js TAP single release > must match snapshot 1`] = `
+exports[`test/release/release-manager.js > TAP > single release > must match snapshot 1`] = `
 ### Release Checklist for v7.5.4
 
 - [ ] 1. Checkout the release branch and test

--- a/tap-snapshots/test/release/release-manager-workspace-names.js.test.cjs
+++ b/tap-snapshots/test/release/release-manager-workspace-names.js.test.cjs
@@ -5,7 +5,7 @@
  * Make sure to inspect the output below.  Do not ignore changes!
  */
 'use strict'
-exports[`test/release/release-manager.js TAP workspace names > expect resolving Promise 1`] = `
+exports[`test/release/release-manager.js > TAP > workspace names > promise must resolve to match snapshot 1`] = `
 ### Release Checklist for v10.2.2
 
 - [ ] 1. Checkout the release branch

--- a/test/apply/esm.js
+++ b/test/apply/esm.js
@@ -19,5 +19,7 @@ t.test('basic', async t => {
   await s.apply()
 
   const file = await s.readFile('file.js')
+
+  process.exit(0)
   t.match(file, 'var x = 1;')
 })

--- a/test/apply/esm.js
+++ b/test/apply/esm.js
@@ -17,8 +17,7 @@ t.test('basic', async t => {
     },
   })
   await s.apply()
-
-  const file = await s.readFile('file.js')
+  const file = await s.readFile('content_dir/file.js')
 
   t.match(file, 'var x = 1;')
 })

--- a/test/apply/esm.js
+++ b/test/apply/esm.js
@@ -20,6 +20,5 @@ t.test('basic', async t => {
 
   const file = await s.readFile('file.js')
 
-  process.exit(0)
   t.match(file, 'var x = 1;')
 })

--- a/test/apply/tap.js
+++ b/test/apply/tap.js
@@ -31,9 +31,6 @@ t.test('tap@16', async t => {
   await s.apply()
   const pkg = await s.readJson('package.json')
   t.strictSame(pkg.tap, {
-    'nyc-arg': [
-      '--exclude',
-      'tap-snapshots/**',
-    ],
+    'nyc-arg': ['--exclude', 'tap-snapshots/**'],
   })
 })

--- a/test/apply/tap.js
+++ b/test/apply/tap.js
@@ -13,7 +13,9 @@ t.test('tap@18', async t => {
 
   await s.apply()
   const pkg = await s.readJson('package.json')
-  t.strictSame(pkg.tap, {})
+  t.strictSame(pkg.tap, {
+    'show-full-coverage': true,
+  })
 })
 
 t.test('tap@16', async t => {
@@ -29,6 +31,9 @@ t.test('tap@16', async t => {
   await s.apply()
   const pkg = await s.readJson('package.json')
   t.strictSame(pkg.tap, {
-    'nyc-arg': ['--exclude', 'tap-snapshots/**'],
+    'nyc-arg': [
+      '--exclude',
+      'tap-snapshots/**',
+    ],
   })
 })

--- a/test/bin/apply.js
+++ b/test/bin/apply.js
@@ -1,7 +1,7 @@
 const t = require('tap')
 
 const templateApply = mocks =>
-  t.mock(
+  t.mockRequire(
     '../../bin/apply.js',
     mocks && {
       '../../lib/apply/index.js': async () => mocks(),

--- a/test/bin/check.js
+++ b/test/bin/check.js
@@ -1,7 +1,7 @@
 const t = require('tap')
 
 const templateCheck = mocks =>
-  t.mock(
+  t.mockRequire(
     '../../bin/check.js',
     mocks && {
       '../../lib/check/index.js': async () => mocks(),

--- a/test/check/snapshots.js
+++ b/test/check/snapshots.js
@@ -17,7 +17,7 @@ t.test('workspaces with empty dir', async t => {
   await t.resolveMatchSnapshot(s.check())
 })
 
-t.test('not ok without required', async t => {
+t.test('not good without required', async t => {
   const s = await setup(t)
   await s.apply()
   await t.resolveMatchSnapshot(s.check())

--- a/test/fixtures/mock-release.js
+++ b/test/fixtures/mock-release.js
@@ -1,9 +1,8 @@
 const nock = require('nock')
-const { resolve, relative, dirname, sep, join, basename, extname } = require('path')
+const { resolve, dirname, join, basename, extname } = require('path')
 const fs = require('fs')
 
 const DIR = __dirname
-const CWD = process.cwd()
 const RECORD = 'NOCK_RECORD' in process.env ? true : undefined
 
 // These are the live GitHub repo and branch that are used to

--- a/test/fixtures/mock-release.js
+++ b/test/fixtures/mock-release.js
@@ -1,5 +1,5 @@
 const nock = require('nock')
-const { resolve, relative, dirname, sep, join, basename } = require('path')
+const { resolve, relative, dirname, sep, join, basename, extname } = require('path')
 const fs = require('fs')
 
 const DIR = __dirname
@@ -12,9 +12,12 @@ const REPO = 'npm/npm-cli-release-please'
 const BRANCH = 'template-oss-mock-testing-branch-do-not-delete'
 
 const getPath = t => {
-  const fixtureName = relative(CWD, t.testdirName).split(`${sep}tap-testdir-`)[1]
+  const fullExt = extname(t.testdirName)
+  const testName = fullExt.replace(/\.js-/, '')
+  const testFileName = basename(t.testdirName, fullExt).replace(/^test-release-/, '')
+  const fixtureName = `${testFileName}-${testName}`
   return {
-    fixtureName: basename(fixtureName),
+    fixtureName,
     fixturePath: resolve(DIR, 'nocks', `${fixtureName}.json`),
   }
 }
@@ -61,7 +64,7 @@ const setup = t => {
 }
 
 const releasePlease = async (t, { setup: s, ...opts } = {}) => {
-  const ReleasePlease = t.mock('../../lib/release/release-please.js')
+  const ReleasePlease = t.mockRequire('../../lib/release/release-please.js')
   try {
     return await ReleasePlease.run({
       token: s.token,
@@ -82,7 +85,7 @@ const releasePlease = async (t, { setup: s, ...opts } = {}) => {
 
 const releaseManager = (t, { cwd = t.testdir({ 'package.json': '{"name":"pkg"}' }), ...opts } = {}) => {
   const s = setup(t)
-  const ReleaseManager = t.mock('../../lib/release/release-manager.js')
+  const ReleaseManager = t.mockRequire('../../lib/release/release-manager.js')
   return ReleaseManager.run({
     token: s.token,
     repo: REPO,

--- a/test/setup.js
+++ b/test/setup.js
@@ -53,12 +53,20 @@ const setupRoot = async (t, root, mocks) => {
   const rootFs = Object.fromEntries(
     Object.entries({
       readdir: fs.readdir,
-      readFile: p => fs.readFile(p, { encoding: 'utf-8' }),
+      readFile: p => {
+        console.log(p)
+        return fs.readFile(p, { encoding: 'utf-8' })
+      },
       writeFile: (p, d) => fs.writeFile(p, d, { encoding: 'utf-8' }),
       appendFile: fs.appendFile,
       stat: fs.stat,
       unlink: fs.unlink,
-    }).map(([k, fn]) => [k, (p, ...rest) => fn(rootPath(p), ...rest)]),
+    }).map(([k, fn]) => [
+      k,
+      (p, ...rest) => {
+        return fn(rootPath(p), ...rest)
+      },
+    ]),
   )
 
   // Returns a recurisve list of relative file
@@ -136,6 +144,8 @@ const setup = async (t, { package = {}, workspaces = {}, testdir = {}, mocks = {
   // creates dir with a root package.json and
   // package.json files for each workspace
   const root = t.testdir(merge(createPackageJson(pkg), testdir))
+
+  console.log({ root })
 
   return {
     ...(await setupRoot(t, root, mocks)),

--- a/test/setup.js
+++ b/test/setup.js
@@ -54,7 +54,6 @@ const setupRoot = async (t, root, mocks) => {
     Object.entries({
       readdir: fs.readdir,
       readFile: p => {
-        console.log(p)
         return fs.readFile(p, { encoding: 'utf-8' })
       },
       writeFile: (p, d) => fs.writeFile(p, d, { encoding: 'utf-8' }),
@@ -144,8 +143,6 @@ const setup = async (t, { package = {}, workspaces = {}, testdir = {}, mocks = {
   // creates dir with a root package.json and
   // package.json files for each workspace
   const root = t.testdir(merge(createPackageJson(pkg), testdir))
-
-  console.log({ root })
 
   return {
     ...(await setupRoot(t, root, mocks)),

--- a/test/setup.js
+++ b/test/setup.js
@@ -88,8 +88,8 @@ const setupRoot = async (t, root, mocks) => {
     return Object.fromEntries(files.map((f, i) => [f, contents[i]]))
   }
 
-  const apply = t.mock('../lib/apply/index.js', mocks)
-  const check = t.mock('../lib/check/index.js', mocks)
+  const apply = t.mockRequire('../lib/apply/index.js', mocks)
+  const check = t.mockRequire('../lib/check/index.js', mocks)
 
   return {
     root,


### PR DESCRIPTION
Resurfaces an old PR that updated tap 16 -> 19 (still not sure what's needed from that until i see the diff. 
Had to do some googling to find why `/* istanbul ignore next */` doesn't work anymore.

https://github.com/tapjs/tapjs/issues/1027

got some node 22
 failures - ENOENT: no such file or directory, open '/home/runner/work/template-oss/template-oss/.tap/fixtures/test-apply-esm.js-basic/file.js'

doesn't work on 20.5.0 because of https://github.com/tapjs/tapjs/pull/1028