### PR TITLE
fix: tap exclude

### DIFF
--- a/lib/content/package-json.hbs
+++ b/lib/content/package-json.hbs
@@ -53,7 +53,7 @@
     "exclude": {{{ del }}},
     {{#if workspacePaths}}
       "exclude": {{#if tap18}}[
-        "{{ join workspaceGlobs "," }}"
+        "{{ json workspaceGlobs }}"
         ]{{else }}{{{ del }}}{{/if}},
       "test-ignore": {{#if tap18}}{{{ del }}}{{else}}"^({{ join workspacePaths "|" }})/"{{/if}},
     {{/if}}


### PR DESCRIPTION
before 

```
    "exclude": [
      "docs/**,smoke-tests/**,mock-globals/**,mock-registry/**,workspaces/**"
    ]
```

after

```
    "exclude": [
      "docs/**",
      "smoke-tests/**",
      "mock-globals/**",
      "mock-registry/**",
      "workspaces/**"
    ],
```