### PR TITLE
chore: allow eslint.config.js in npm project gitignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 !**/.gitignore
 !/.commitlintrc.js
+!/.eslint.config.js
 !/.eslintrc.js
 !/.eslintrc.local.*
 !/.git-blame-ignore-revs

--- a/lib/content/index.js
+++ b/lib/content/index.js
@@ -157,6 +157,7 @@ module.exports = {
   allowDistPaths: true,
   allowPaths: [
     '/.eslintrc.local.*',
+    '/.eslint.config.js',
     '**/.gitignore',
     '/docs/',
     '/tap-snapshots/',

--- a/tap-snapshots/test/apply/source-snapshots.js.test.cjs
+++ b/tap-snapshots/test/apply/source-snapshots.js.test.cjs
@@ -1255,6 +1255,7 @@ jobs:
 
 !**/.gitignore
 !/.commitlintrc.js
+!/.eslint.config.js
 !/.eslintrc.js
 !/.eslintrc.local.*
 !/.git-blame-ignore-revs
@@ -2940,6 +2941,7 @@ jobs:
 
 !**/.gitignore
 !/.commitlintrc.js
+!/.eslint.config.js
 !/.eslintrc.js
 !/.eslintrc.local.*
 !/.git-blame-ignore-revs
@@ -3188,6 +3190,7 @@ workspaces/a/.gitignore
 /*
 
 !**/.gitignore
+!/.eslint.config.js
 !/.eslintrc.js
 !/.eslintrc.local.*
 !/.git-blame-ignore-revs
@@ -3268,6 +3271,7 @@ workspaces/b/.gitignore
 /*
 
 !**/.gitignore
+!/.eslint.config.js
 !/.eslintrc.js
 !/.eslintrc.local.*
 !/.git-blame-ignore-revs
@@ -4569,6 +4573,7 @@ workspaces/a/.gitignore
 /*
 
 !**/.gitignore
+!/.eslint.config.js
 !/.eslintrc.js
 !/.eslintrc.local.*
 !/.git-blame-ignore-revs
@@ -4649,6 +4654,7 @@ workspaces/b/.gitignore
 /*
 
 !**/.gitignore
+!/.eslint.config.js
 !/.eslintrc.js
 !/.eslintrc.local.*
 !/.git-blame-ignore-revs

--- a/tap-snapshots/test/check/snapshots.js.test.cjs
+++ b/tap-snapshots/test/check/snapshots.js.test.cjs
@@ -126,6 +126,7 @@ To correct it: move files to not match one of the following patterns:
   /*
   !**/.gitignore
   !/.commitlintrc.js
+  !/.eslint.config.js
   !/.eslintrc.js
   !/.eslintrc.local.*
   !/.git-blame-ignore-revs
@@ -170,6 +171,7 @@ To correct it: move files to not match one of the following patterns:
   /*
   !**/.gitignore
   !/.commitlintrc.js
+  !/.eslint.config.js
   !/.eslintrc.js
   !/.eslintrc.local.*
   !/.git-blame-ignore-revs
@@ -211,6 +213,7 @@ To correct it: move files to not match one of the following patterns:
 
   /*
   !**/.gitignore
+  !/.eslint.config.js
   !/.eslintrc.js
   !/.eslintrc.local.*
   !/.git-blame-ignore-revs
@@ -238,6 +241,7 @@ To correct it: move files to not match one of the following patterns:
 
   /*
   !**/.gitignore
+  !/.eslint.config.js
   !/.eslintrc.js
   !/.eslintrc.local.*
   !/.git-blame-ignore-revs

--- a/workspace/test-workspace/.gitignore
+++ b/workspace/test-workspace/.gitignore
@@ -4,6 +4,7 @@
 /*
 
 !**/.gitignore
+!/.eslint.config.js
 !/.eslintrc.js
 !/.eslintrc.local.*
 !/.git-blame-ignore-revs


### PR DESCRIPTION
https://github.com/npm/documentation/pull/1518 the github eslint plugin is now esm only in 6.0.0. We need to be able to add an eslint.config to adapt.