### PR TITLE
Add config for jsdoc support

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -194,6 +194,7 @@ const getFullConfig = async ({
     __NAME__: NAME,
     __CONFIG_KEY__: CONFIG_KEY,
     __VERSION__: LATEST_VERSION,
+    jsdoc: pkgConfig.jsdoc,
   }
 
   if (!pkgConfig.eslint && Array.isArray(pkgConfig.requiredPackages?.devDependencies)) {

--- a/lib/config.js
+++ b/lib/config.js
@@ -241,6 +241,16 @@ const getFullConfig = async ({
     ])
   }
 
+  if (pkgConfig.jsdoc) {
+    defaultsDeep(pkgConfig, { requiredPackages: { devDependencies: [] } })
+    pkgConfig.requiredPackages.devDependencies = uniq([
+      ...pkgConfig.requiredPackages.devDependencies,
+      'typescript',
+      '@typescript-eslint/parser',
+      '@types/node'
+    ])
+  }
+
   const gitUrl = await git.getUrl(rootPkg.path)
   if (gitUrl) {
     derived.repository = {

--- a/lib/content/eslintrc-js.hbs
+++ b/lib/content/eslintrc-js.hbs
@@ -21,6 +21,9 @@ module.exports = {
     },
   },
   {{/if}}
+  {{#if jsdoc}}
+  parser: '@typescript-eslint/parser',
+  {{/if}}
   extends: [
     '@npmcli',
     ...localConfigs,

--- a/lib/content/index.js
+++ b/lib/content/index.js
@@ -28,7 +28,7 @@ const sharedRootAdd = name => ({
   },
   'tsconfig.json': {
     file: 'tsconfig-json.hbs',
-    filter: p => p.config.typescript,
+    filter: p => p.config.typescript || p.config.jsdoc,
     parser: p => p.JsonMergeNoComment,
   },
   // this lint commits which is only necessary for releases

--- a/lib/content/tsconfig-json.hbs
+++ b/lib/content/tsconfig-json.hbs
@@ -1,3 +1,21 @@
+{{#if jsdoc}}
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "node16",
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "strict": true,
+    "moduleResolution": "node16",
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "types": ["node"]
+  },
+  "include": ["lib/**/*.js"]
+}
+{{else}}
 {
   "compilerOptions": {
     "jsx": "react",
@@ -15,3 +33,4 @@
     "module": "nodenext"
   }
 }
+{{/if}}

--- a/lib/content/tsconfig-json.hbs
+++ b/lib/content/tsconfig-json.hbs
@@ -5,7 +5,8 @@
     "module": "node16",
     "allowJs": true,
     "checkJs": true,
-    "noEmit": true,
+    "declaration": true,
+    "emitDeclarationOnly": true,
     "strict": true,
     "moduleResolution": "node16",
     "esModuleInterop": true,
@@ -13,7 +14,7 @@
     "skipLibCheck": true,
     "types": ["node"]
   },
-  "include": ["lib/**/*.js"]
+  "include": ["lib/**/*.js", "lib/**/*.ts"]
 }
 {{else}}
 {


### PR DESCRIPTION
I want to add jsdoc support to the CLI and packages like `proc-log` and `npm-registry-fetch`. 

This would involve bumping `template-oss` and `npm i -D typescript @types/node`.