### PR TITLE
feat: move node14 tests to macos-15-intel

### DIFF
--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -85,7 +85,7 @@ jobs:
             os: macos-latest
             shell: bash
           - name: macOS
-            os: macos-13
+            os: macos-15-intel
             shell: bash
           - name: Windows
             os: windows-latest
@@ -96,13 +96,13 @@ jobs:
           - 22.9.0
           - 22.x
         exclude:
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 20.17.0
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 20.x
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 22.9.0
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 22.x
     runs-on: ${{ matrix.platform.os }}
     defaults:

--- a/.github/workflows/ci-test-workspace.yml
+++ b/.github/workflows/ci-test-workspace.yml
@@ -65,7 +65,7 @@ jobs:
             os: macos-latest
             shell: bash
           - name: macOS
-            os: macos-13
+            os: macos-15-intel
             shell: bash
           - name: Windows
             os: windows-latest
@@ -77,15 +77,15 @@ jobs:
           - 20.x
           - 22.x
         exclude:
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 18.17.0
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 18.x
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 20.5.0
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 20.x
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 22.x
     runs-on: ${{ matrix.platform.os }}
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
             os: macos-latest
             shell: bash
           - name: macOS
-            os: macos-13
+            os: macos-15-intel
             shell: bash
           - name: Windows
             os: windows-latest
@@ -76,13 +76,13 @@ jobs:
           - 22.9.0
           - 22.x
         exclude:
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 20.17.0
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 20.x
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 22.9.0
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 22.x
     runs-on: ${{ matrix.platform.os }}
     defaults:

--- a/lib/content/_job-matrix-yml.hbs
+++ b/lib/content/_job-matrix-yml.hbs
@@ -12,7 +12,7 @@ strategy:
         os: macos-latest
         shell: bash
       - name: macOS
-        os: macos-13
+        os: macos-15-intel
         shell: bash
       {{/if}}
       {{#if windowsCI}}
@@ -27,7 +27,8 @@ strategy:
     {{#if macCI}}
     exclude:
       {{#each ciVersions}}
-      - platform: {name: macOS, os: macos-{{#if (lte (semverRangeMajor .) 14)}}latest{{else}}13{{/if}}, shell: bash}
+        {{!-- M1 macs do not have builds of node 14 and below --}}
+      - platform: {name: macOS, os: {{#if (lte (semverRangeMajor .) 14)}}macos-latest{{else}}macos-15-intel{{/if}}, shell: bash}
         node-version: {{ . }}
       {{/each}}
     {{/if}}

--- a/tap-snapshots/test/apply/source-snapshots.js.test.cjs
+++ b/tap-snapshots/test/apply/source-snapshots.js.test.cjs
@@ -480,7 +480,7 @@ jobs:
             os: macos-latest
             shell: bash
           - name: macOS
-            os: macos-13
+            os: macos-15-intel
             shell: bash
           - name: Windows
             os: windows-latest
@@ -488,7 +488,7 @@ jobs:
         node-version:
           - 22.x
         exclude:
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 22.x
     runs-on: \${{ matrix.platform.os }}
     defaults:
@@ -602,7 +602,7 @@ jobs:
             os: macos-latest
             shell: bash
           - name: macOS
-            os: macos-13
+            os: macos-15-intel
             shell: bash
           - name: Windows
             os: windows-latest
@@ -610,7 +610,7 @@ jobs:
         node-version:
           - 22.x
         exclude:
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 22.x
     runs-on: \${{ matrix.platform.os }}
     defaults:
@@ -1923,7 +1923,7 @@ jobs:
             os: macos-latest
             shell: bash
           - name: macOS
-            os: macos-13
+            os: macos-15-intel
             shell: bash
           - name: Windows
             os: windows-latest
@@ -1931,7 +1931,7 @@ jobs:
         node-version:
           - 22.x
         exclude:
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 22.x
     runs-on: \${{ matrix.platform.os }}
     defaults:
@@ -2032,7 +2032,7 @@ jobs:
             os: macos-latest
             shell: bash
           - name: macOS
-            os: macos-13
+            os: macos-15-intel
             shell: bash
           - name: Windows
             os: windows-latest
@@ -2040,7 +2040,7 @@ jobs:
         node-version:
           - 22.x
         exclude:
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 22.x
     runs-on: \${{ matrix.platform.os }}
     defaults:
@@ -2159,7 +2159,7 @@ jobs:
             os: macos-latest
             shell: bash
           - name: macOS
-            os: macos-13
+            os: macos-15-intel
             shell: bash
           - name: Windows
             os: windows-latest
@@ -2167,7 +2167,7 @@ jobs:
         node-version:
           - 22.x
         exclude:
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 22.x
     runs-on: \${{ matrix.platform.os }}
     defaults:
@@ -2287,7 +2287,7 @@ jobs:
             os: macos-latest
             shell: bash
           - name: macOS
-            os: macos-13
+            os: macos-15-intel
             shell: bash
           - name: Windows
             os: windows-latest
@@ -2295,7 +2295,7 @@ jobs:
         node-version:
           - 22.x
         exclude:
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 22.x
     runs-on: \${{ matrix.platform.os }}
     defaults:
@@ -3623,7 +3623,7 @@ jobs:
             os: macos-latest
             shell: bash
           - name: macOS
-            os: macos-13
+            os: macos-15-intel
             shell: bash
           - name: Windows
             os: windows-latest
@@ -3631,7 +3631,7 @@ jobs:
         node-version:
           - 22.x
         exclude:
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 22.x
     runs-on: \${{ matrix.platform.os }}
     defaults:
@@ -3732,7 +3732,7 @@ jobs:
             os: macos-latest
             shell: bash
           - name: macOS
-            os: macos-13
+            os: macos-15-intel
             shell: bash
           - name: Windows
             os: windows-latest
@@ -3740,7 +3740,7 @@ jobs:
         node-version:
           - 22.x
         exclude:
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 22.x
     runs-on: \${{ matrix.platform.os }}
     defaults:
@@ -3859,7 +3859,7 @@ jobs:
             os: macos-latest
             shell: bash
           - name: macOS
-            os: macos-13
+            os: macos-15-intel
             shell: bash
           - name: Windows
             os: windows-latest
@@ -3867,7 +3867,7 @@ jobs:
         node-version:
           - 22.x
         exclude:
-          - platform: { name: macOS, os: macos-13, shell: bash }
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 22.x
     runs-on: \${{ matrix.platform.os }}
     defaults:


### PR DESCRIPTION
See https://github.com/npm/template-oss/pull/440 for more info on node versions and M1 macos