### PR TITLE
fix: skip npm update on node 22

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -32,10 +32,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund --package-lock
       - name: Run Production Audit

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -53,10 +53,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Lint
@@ -132,6 +128,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
       - name: Install Latest npm
+        if: ${{ !startsWith(matrix.node-version, '22.') }}
         uses: ./.github/actions/install-latest-npm
         with:
           node: ${{ steps.node.outputs.node-version }}

--- a/.github/workflows/ci-test-workspace.yml
+++ b/.github/workflows/ci-test-workspace.yml
@@ -40,10 +40,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Lint
@@ -105,6 +101,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
       - name: Install Latest npm
+        if: ${{ !startsWith(matrix.node-version, '22.') }}
         uses: ./.github/actions/install-latest-npm
         with:
           node: ${{ steps.node.outputs.node-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Lint
@@ -102,6 +98,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
       - name: Install Latest npm
+        if: ${{ !startsWith(matrix.node-version, '22.') }}
         uses: ./.github/actions/install-latest-npm
         with:
           node: ${{ steps.node.outputs.node-version }}

--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -30,10 +30,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Fetch Dependabot Metadata

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -36,10 +36,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Run Commitlint on Commits

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -47,10 +47,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Set npm authToken

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,10 +41,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Release Please
@@ -121,10 +117,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Create Release Manager Checklist Text

--- a/lib/content/_step-node-yml.hbs
+++ b/lib/content/_step-node-yml.hbs
@@ -8,8 +8,18 @@
     cache: npm
     {{/if}}
 {{#if updateNpm}}
+{{#if jobIsMatrix}}
+- name: Install Latest npm
+  if: $\{{ !startsWith(matrix.node-version, '22.') }}
+  uses: ./.github/actions/install-latest-npm
+  with:
+    node: $\{{ steps.node.outputs.node-version }}
+{{else}}
+{{~#unless (eq (semverRangeMajor (last ciVersions)) 22)}}
 - name: Install Latest npm
   uses: ./.github/actions/install-latest-npm
   with:
     node: $\{{ steps.node.outputs.node-version }}
+{{/unless}}
+{{/if}}
 {{/if}}

--- a/lib/util/template.js
+++ b/lib/util/template.js
@@ -43,6 +43,7 @@ const setupHandlebars = dirs => {
   Handlebars.registerHelper('del', () => JSON.stringify(DELETE))
   Handlebars.registerHelper('semverRangeMajor', v => new Range(v).set[0][0].semver.major)
   Handlebars.registerHelper('lte', (a, b) => a <= b)
+  Handlebars.registerHelper('eq', (a, b) => a === b)
 
   if (Array.isArray(dirs)) {
     const [baseDir, ...otherDirs] = dirs

--- a/tap-snapshots/test/apply/source-snapshots.js.test.cjs
+++ b/tap-snapshots/test/apply/source-snapshots.js.test.cjs
@@ -380,10 +380,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund --package-lock
       - name: Run Production Audit
@@ -448,10 +444,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Lint
@@ -518,6 +510,7 @@ jobs:
           node-version: \${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
       - name: Install Latest npm
+        if: \${{ !startsWith(matrix.node-version, '22.') }}
         uses: ./.github/actions/install-latest-npm
         with:
           node: \${{ steps.node.outputs.node-version }}
@@ -577,10 +570,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Lint
@@ -630,6 +619,7 @@ jobs:
           node-version: \${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
       - name: Install Latest npm
+        if: \${{ !startsWith(matrix.node-version, '22.') }}
         uses: ./.github/actions/install-latest-npm
         with:
           node: \${{ steps.node.outputs.node-version }}
@@ -720,10 +710,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Fetch Dependabot Metadata
@@ -852,10 +838,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Run Commitlint on Commits
@@ -911,10 +893,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Check If Published
@@ -984,10 +962,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Release Please
@@ -1064,10 +1038,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Create Release Manager Checklist Text
@@ -1841,10 +1811,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund --package-lock
       - name: Run Production Audit
@@ -1898,10 +1864,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Lint
@@ -1951,6 +1913,7 @@ jobs:
           node-version: \${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
       - name: Install Latest npm
+        if: \${{ !startsWith(matrix.node-version, '22.') }}
         uses: ./.github/actions/install-latest-npm
         with:
           node: \${{ steps.node.outputs.node-version }}
@@ -2007,10 +1970,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Lint
@@ -2060,6 +2019,7 @@ jobs:
           node-version: \${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
       - name: Install Latest npm
+        if: \${{ !startsWith(matrix.node-version, '22.') }}
         uses: ./.github/actions/install-latest-npm
         with:
           node: \${{ steps.node.outputs.node-version }}
@@ -2127,10 +2087,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Lint
@@ -2197,6 +2153,7 @@ jobs:
           node-version: \${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
       - name: Install Latest npm
+        if: \${{ !startsWith(matrix.node-version, '22.') }}
         uses: ./.github/actions/install-latest-npm
         with:
           node: \${{ steps.node.outputs.node-version }}
@@ -2262,10 +2219,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Lint
@@ -2315,6 +2268,7 @@ jobs:
           node-version: \${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
       - name: Install Latest npm
+        if: \${{ !startsWith(matrix.node-version, '22.') }}
         uses: ./.github/actions/install-latest-npm
         with:
           node: \${{ steps.node.outputs.node-version }}
@@ -2405,10 +2359,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Fetch Dependabot Metadata
@@ -2537,10 +2487,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Run Commitlint on Commits
@@ -2596,10 +2542,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Check If Published
@@ -2669,10 +2611,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Release Please
@@ -2749,10 +2687,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Create Release Manager Checklist Text
@@ -3598,10 +3532,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Lint
@@ -3651,6 +3581,7 @@ jobs:
           node-version: \${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
       - name: Install Latest npm
+        if: \${{ !startsWith(matrix.node-version, '22.') }}
         uses: ./.github/actions/install-latest-npm
         with:
           node: \${{ steps.node.outputs.node-version }}
@@ -3707,10 +3638,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Lint
@@ -3760,6 +3687,7 @@ jobs:
           node-version: \${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
       - name: Install Latest npm
+        if: \${{ !startsWith(matrix.node-version, '22.') }}
         uses: ./.github/actions/install-latest-npm
         with:
           node: \${{ steps.node.outputs.node-version }}
@@ -3827,10 +3755,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Lint
@@ -3897,6 +3821,7 @@ jobs:
           node-version: \${{ matrix.node-version }}
           check-latest: contains(matrix.node-version, '.x')
       - name: Install Latest npm
+        if: \${{ !startsWith(matrix.node-version, '22.') }}
         uses: ./.github/actions/install-latest-npm
         with:
           node: \${{ steps.node.outputs.node-version }}
@@ -3948,10 +3873,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Fetch Dependabot Metadata
@@ -4080,10 +4001,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Run Commitlint on Commits
@@ -4139,10 +4056,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Check If Published
@@ -4212,10 +4125,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Release Please
@@ -4292,10 +4201,6 @@ jobs:
         with:
           node-version: 22.x
           check-latest: contains('22.x', '.x')
-      - name: Install Latest npm
-        uses: ./.github/actions/install-latest-npm
-        with:
-          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Create Release Manager Checklist Text

--- a/tap-snapshots/test/check/diff-snapshots.js.test.cjs
+++ b/tap-snapshots/test/check/diff-snapshots.js.test.cjs
@@ -99,23 +99,23 @@ The repo file audit.yml needs to be updated:
   [@npmcli/template-oss ERROR] There was an erroring getting the target file
   [@npmcli/template-oss ERROR] Error: {{ROOT}}/.tap/fixtures/test-check-diff-snapshots.js-update-and-remove-errors/.github/workflows/audit.yml
   
-  YAMLParseError: Implicit keys need to be on a single line at line 45, column 1:
+  YAMLParseError: Implicit keys need to be on a single line at line 41, column 1:
   
           run: npm audit --audit-level=none
   >>>>I HOPE THIS IS NOT VALID YAML<<<<<<<<<<<
   ^
   
-  YAMLParseError: Block scalar header includes extra characters: >>>>I at line 45, column 2:
+  YAMLParseError: Block scalar header includes extra characters: >>>>I at line 41, column 2:
   
   >>>>I HOPE THIS IS NOT VALID YAML<<<<<<<<<<<
    ^
   
-  YAMLParseError: Not a YAML token: HOPE THIS IS NOT VALID YAML<<<<<<<<<<< at line 45, column 7:
+  YAMLParseError: Not a YAML token: HOPE THIS IS NOT VALID YAML<<<<<<<<<<< at line 41, column 7:
   
   >>>>I HOPE THIS IS NOT VALID YAML<<<<<<<<<<<
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   
-  YAMLParseError: Implicit map keys need to be followed by map values at line 45, column 1:
+  YAMLParseError: Implicit map keys need to be followed by map values at line 41, column 1:
   
           run: npm audit --audit-level=none
   >>>>I HOPE THIS IS NOT VALID YAML<<<<<<<<<<<
@@ -158,10 +158,6 @@ The repo file audit.yml needs to be updated:
           with:
             node-version: 22.x
             check-latest: contains('22.x', '.x')
-        - name: Install Latest npm
-          uses: ./.github/actions/install-latest-npm
-          with:
-            node: \${{ steps.node.outputs.node-version }}
         - name: Install Dependencies
           run: npm i --ignore-scripts --no-audit --no-fund --package-lock
         - name: Run Production Audit
@@ -178,12 +174,11 @@ The repo file ci.yml needs to be updated:
 
   .github/workflows/ci.yml
   ========================================
-  @@ -100,4 +100,24 @@
-           shell: \${{ matrix.platform.shell }}
+  @@ -97,4 +97,24 @@
        steps:
          - name: Checkout
            uses: actions/checkout@v4
-  +      - name: Setup Git User
+         - name: Setup Git User
   +        run: |
   +          git config --global user.email "npm-cli+bot@github.com"
   +          git config --global user.name "npm CLI robot"
@@ -194,6 +189,7 @@ The repo file ci.yml needs to be updated:
   +          node-version: \${{ matrix.node-version }}
   +          check-latest: contains(matrix.node-version, '.x')
   +      - name: Install Latest npm
+  +        if: \${{ !startsWith(matrix.node-version, '22.') }}
   +        uses: ./.github/actions/install-latest-npm
   +        with:
   +          node: \${{ steps.node.outputs.node-version }}


### PR DESCRIPTION
We've been 1-shotting these in the repos, but time to just not run it for node 22

### Why?

updating from npm 10 to npm 11 in node 22 is broken. THis means CI doesn't pass in our ~60 repos for node 22 and makes merging difficult.

we should do this before the engine updates for every single repo