### PR TITLE
feat!: drop Node 20 test workaround

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -30,8 +30,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund --package-lock
       - name: Run Production Audit

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -51,8 +51,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Lint
@@ -87,19 +91,25 @@ jobs:
             os: windows-latest
             shell: cmd
         node-version:
-          - 20.17.0
-          - 20.x
-          - 22.9.0
+          - 22.22.2
           - 22.x
+          - 24.15.0
+          - 24.x
+          - 26.0.0
+          - 26.x
         exclude:
           - platform: { name: macOS, os: macos-15-intel, shell: bash }
-            node-version: 20.17.0
-          - platform: { name: macOS, os: macos-15-intel, shell: bash }
-            node-version: 20.x
-          - platform: { name: macOS, os: macos-15-intel, shell: bash }
-            node-version: 22.9.0
+            node-version: 22.22.2
           - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 22.x
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
+            node-version: 24.15.0
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
+            node-version: 24.x
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
+            node-version: 26.0.0
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
+            node-version: 26.x
     runs-on: ${{ matrix.platform.os }}
     defaults:
       run:

--- a/.github/workflows/ci-test-workspace.yml
+++ b/.github/workflows/ci-test-workspace.yml
@@ -38,8 +38,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Lint
@@ -67,22 +71,25 @@ jobs:
             os: windows-latest
             shell: cmd
         node-version:
-          - 18.17.0
-          - 18.x
-          - 20.5.0
-          - 20.x
+          - 22.22.2
           - 22.x
+          - 24.15.0
+          - 24.x
+          - 26.0.0
+          - 26.x
         exclude:
           - platform: { name: macOS, os: macos-15-intel, shell: bash }
-            node-version: 18.17.0
-          - platform: { name: macOS, os: macos-15-intel, shell: bash }
-            node-version: 18.x
-          - platform: { name: macOS, os: macos-15-intel, shell: bash }
-            node-version: 20.5.0
-          - platform: { name: macOS, os: macos-15-intel, shell: bash }
-            node-version: 20.x
+            node-version: 22.22.2
           - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 22.x
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
+            node-version: 24.15.0
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
+            node-version: 24.x
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
+            node-version: 26.0.0
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
+            node-version: 26.x
     runs-on: ${{ matrix.platform.os }}
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Lint
@@ -67,19 +71,25 @@ jobs:
             os: windows-latest
             shell: cmd
         node-version:
-          - 20.17.0
-          - 20.x
-          - 22.9.0
+          - 22.22.2
           - 22.x
+          - 24.15.0
+          - 24.x
+          - 26.0.0
+          - 26.x
         exclude:
           - platform: { name: macOS, os: macos-15-intel, shell: bash }
-            node-version: 20.17.0
-          - platform: { name: macOS, os: macos-15-intel, shell: bash }
-            node-version: 20.x
-          - platform: { name: macOS, os: macos-15-intel, shell: bash }
-            node-version: 22.9.0
+            node-version: 22.22.2
           - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 22.x
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
+            node-version: 24.15.0
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
+            node-version: 24.x
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
+            node-version: 26.0.0
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
+            node-version: 26.x
     runs-on: ${{ matrix.platform.os }}
     defaults:
       run:

--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -28,8 +28,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Fetch Dependabot Metadata

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -34,8 +34,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Run Commitlint on Commits

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -45,8 +45,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Set npm authToken

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,8 +39,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Release Please
@@ -115,8 +119,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: ${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Create Release Manager Checklist Text

--- a/lib/content/_step-test-yml.hbs
+++ b/lib/content/_step-test-yml.hbs
@@ -6,11 +6,8 @@
 - name: Test (with coverage on Node >= 24)
   if: $\{{ startsWith(matrix.node-version, '24') }}
   run: {{ rootNpmPath }} run test:cover --ignore-scripts {{~#if jobRunFlags}} {{ jobRunFlags }}{{/if}}
-- name: Test (on Node 20 with globbing workaround)
-  if: $\{{ startsWith(matrix.node-version, '20') }}
-  run: {{ rootNpmPath }} run test:node20 --ignore-scripts {{~#if jobRunFlags}} {{ jobRunFlags }}{{/if}}
-- name: Test
-  if: $\{{ !startsWith(matrix.node-version, '24') && !startsWith(matrix.node-version, '20') }}
+- name: Test (without coverage on Node < 24)
+  if: $\{{ !startsWith(matrix.node-version, '24') }}
   run: {{ rootNpmPath }} test --ignore-scripts {{~#if jobRunFlags}} {{ jobRunFlags }}{{/if}}
 {{else}}
 - name: Test

--- a/lib/content/index.js
+++ b/lib/content/index.js
@@ -180,7 +180,7 @@ module.exports = {
   formatIgnorePaths: ['tap-snapshots/', 'test/fixtures/**/*.json'],
   formatExtensions: ['js', 'cjs', 'ts', 'mjs', 'jsx', 'tsx', 'json'],
   ciVersions: {},
-  latestCiVersion: 22,
+  latestCiVersion: 26,
   lockfile: false,
   codeowner: '@npm/cli-team',
   eslint: true,

--- a/lib/content/package-json.hbs
+++ b/lib/content/package-json.hbs
@@ -20,7 +20,6 @@
     {{#if isNodeTest}}
     "snap": "node --test --test-update-snapshots './test/**/*.js'",
     "test": "node --test './test/**/*.js'",
-    "test:node20": "node --test test",
     "test:cover": "node --test --experimental-test-coverage --test-timeout=3000{{#if coverageThreshold}} --test-coverage-lines={{coverageThreshold}} --test-coverage-functions={{coverageThreshold}} --test-coverage-branches={{coverageThreshold}}{{/if}} './test/**/*.js'",
     {{else}}
     "snap": "{{#if typescript}}{{#if tap16}}c8 {{/if}}{{/if}}tap",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "prettier": true
   },
   "engines": {
-    "node": "^20.17.0 || >=22.9.0"
+    "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
   },
   "workspaces": [
     "workspace/test-workspace"

--- a/tap-snapshots/test/apply/source-snapshots.js.test.cjs
+++ b/tap-snapshots/test/apply/source-snapshots.js.test.cjs
@@ -378,8 +378,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund --package-lock
       - name: Run Production Audit
@@ -442,8 +446,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Lint
@@ -478,10 +486,10 @@ jobs:
             os: windows-latest
             shell: cmd
         node-version:
-          - 22.x
+          - 26.x
         exclude:
           - platform: { name: macOS, os: macos-15-intel, shell: bash }
-            node-version: 22.x
+            node-version: 26.x
     runs-on: \${{ matrix.platform.os }}
     defaults:
       run:
@@ -568,8 +576,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Lint
@@ -597,10 +609,10 @@ jobs:
             os: windows-latest
             shell: cmd
         node-version:
-          - 22.x
+          - 26.x
         exclude:
           - platform: { name: macOS, os: macos-15-intel, shell: bash }
-            node-version: 22.x
+            node-version: 26.x
     runs-on: \${{ matrix.platform.os }}
     defaults:
       run:
@@ -708,8 +720,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Fetch Dependabot Metadata
@@ -836,8 +852,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Run Commitlint on Commits
@@ -891,8 +911,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Check If Published
@@ -960,8 +984,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Release Please
@@ -1036,8 +1064,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Create Release Manager Checklist Text
@@ -1809,8 +1841,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund --package-lock
       - name: Run Production Audit
@@ -1862,8 +1898,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Lint
@@ -1891,10 +1931,10 @@ jobs:
             os: windows-latest
             shell: cmd
         node-version:
-          - 22.x
+          - 26.x
         exclude:
           - platform: { name: macOS, os: macos-15-intel, shell: bash }
-            node-version: 22.x
+            node-version: 26.x
     runs-on: \${{ matrix.platform.os }}
     defaults:
       run:
@@ -1968,8 +2008,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Lint
@@ -1997,10 +2041,10 @@ jobs:
             os: windows-latest
             shell: cmd
         node-version:
-          - 22.x
+          - 26.x
         exclude:
           - platform: { name: macOS, os: macos-15-intel, shell: bash }
-            node-version: 22.x
+            node-version: 26.x
     runs-on: \${{ matrix.platform.os }}
     defaults:
       run:
@@ -2085,8 +2129,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Lint
@@ -2121,10 +2169,10 @@ jobs:
             os: windows-latest
             shell: cmd
         node-version:
-          - 22.x
+          - 26.x
         exclude:
           - platform: { name: macOS, os: macos-15-intel, shell: bash }
-            node-version: 22.x
+            node-version: 26.x
     runs-on: \${{ matrix.platform.os }}
     defaults:
       run:
@@ -2217,8 +2265,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Lint
@@ -2246,10 +2298,10 @@ jobs:
             os: windows-latest
             shell: cmd
         node-version:
-          - 22.x
+          - 26.x
         exclude:
           - platform: { name: macOS, os: macos-15-intel, shell: bash }
-            node-version: 22.x
+            node-version: 26.x
     runs-on: \${{ matrix.platform.os }}
     defaults:
       run:
@@ -2357,8 +2409,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Fetch Dependabot Metadata
@@ -2485,8 +2541,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Run Commitlint on Commits
@@ -2540,8 +2600,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Check If Published
@@ -2609,8 +2673,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Release Please
@@ -2685,8 +2753,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Create Release Manager Checklist Text
@@ -3530,8 +3602,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Lint
@@ -3559,10 +3635,10 @@ jobs:
             os: windows-latest
             shell: cmd
         node-version:
-          - 22.x
+          - 26.x
         exclude:
           - platform: { name: macOS, os: macos-15-intel, shell: bash }
-            node-version: 22.x
+            node-version: 26.x
     runs-on: \${{ matrix.platform.os }}
     defaults:
       run:
@@ -3636,8 +3712,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Lint
@@ -3665,10 +3745,10 @@ jobs:
             os: windows-latest
             shell: cmd
         node-version:
-          - 22.x
+          - 26.x
         exclude:
           - platform: { name: macOS, os: macos-15-intel, shell: bash }
-            node-version: 22.x
+            node-version: 26.x
     runs-on: \${{ matrix.platform.os }}
     defaults:
       run:
@@ -3753,8 +3833,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Lint
@@ -3789,10 +3873,10 @@ jobs:
             os: windows-latest
             shell: cmd
         node-version:
-          - 22.x
+          - 26.x
         exclude:
           - platform: { name: macOS, os: macos-15-intel, shell: bash }
-            node-version: 22.x
+            node-version: 26.x
     runs-on: \${{ matrix.platform.os }}
     defaults:
       run:
@@ -3871,8 +3955,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Fetch Dependabot Metadata
@@ -3999,8 +4087,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Run Commitlint on Commits
@@ -4054,8 +4146,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Check If Published
@@ -4123,8 +4219,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Release Please
@@ -4199,8 +4299,12 @@ jobs:
         uses: actions/setup-node@v4
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
+      - name: Install Latest npm
+        uses: ./.github/actions/install-latest-npm
+        with:
+          node: \${{ steps.node.outputs.node-version }}
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Create Release Manager Checklist Text

--- a/tap-snapshots/test/check/diff-snapshots.js.test.cjs
+++ b/tap-snapshots/test/check/diff-snapshots.js.test.cjs
@@ -99,23 +99,23 @@ The repo file audit.yml needs to be updated:
   [@npmcli/template-oss ERROR] There was an erroring getting the target file
   [@npmcli/template-oss ERROR] Error: {{ROOT}}/.tap/fixtures/test-check-diff-snapshots.js-update-and-remove-errors/.github/workflows/audit.yml
   
-  YAMLParseError: Implicit keys need to be on a single line at line 41, column 1:
+  YAMLParseError: Implicit keys need to be on a single line at line 45, column 1:
   
           run: npm audit --audit-level=none
   >>>>I HOPE THIS IS NOT VALID YAML<<<<<<<<<<<
   ^
   
-  YAMLParseError: Block scalar header includes extra characters: >>>>I at line 41, column 2:
+  YAMLParseError: Block scalar header includes extra characters: >>>>I at line 45, column 2:
   
   >>>>I HOPE THIS IS NOT VALID YAML<<<<<<<<<<<
    ^
   
-  YAMLParseError: Not a YAML token: HOPE THIS IS NOT VALID YAML<<<<<<<<<<< at line 41, column 7:
+  YAMLParseError: Not a YAML token: HOPE THIS IS NOT VALID YAML<<<<<<<<<<< at line 45, column 7:
   
   >>>>I HOPE THIS IS NOT VALID YAML<<<<<<<<<<<
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   
-  YAMLParseError: Implicit map keys need to be followed by map values at line 41, column 1:
+  YAMLParseError: Implicit map keys need to be followed by map values at line 45, column 1:
   
           run: npm audit --audit-level=none
   >>>>I HOPE THIS IS NOT VALID YAML<<<<<<<<<<<
@@ -156,8 +156,12 @@ The repo file audit.yml needs to be updated:
           uses: actions/setup-node@v4
           id: node
           with:
-            node-version: 22.x
-            check-latest: contains('22.x', '.x')
+            node-version: 26.x
+            check-latest: contains('26.x', '.x')
+        - name: Install Latest npm
+          uses: ./.github/actions/install-latest-npm
+          with:
+            node: \${{ steps.node.outputs.node-version }}
         - name: Install Dependencies
           run: npm i --ignore-scripts --no-audit --no-fund --package-lock
         - name: Run Production Audit
@@ -174,7 +178,7 @@ The repo file ci.yml needs to be updated:
 
   .github/workflows/ci.yml
   ========================================
-  @@ -97,4 +97,24 @@
+  @@ -107,4 +107,24 @@
        steps:
          - name: Checkout
            uses: actions/checkout@v4

--- a/test/apply/engines.js
+++ b/test/apply/engines.js
@@ -29,8 +29,8 @@ t.test('sets ci versions from engines', async t => {
   t.equal(pkg.engines.node, '>=10')
 
   const versions = await getCiJobs(s)
-  t.equal(versions.lint, '22.x')
-  t.strictSame(versions.test, ['10.0.0', '10.x', '14.x', '16.x', '18.x', '20.x', '22.x'])
+  t.equal(versions.lint, '26.x')
+  t.strictSame(versions.test, ['10.0.0', '10.x', '14.x', '16.x', '18.x', '20.x', '22.x', '24.x', '26.x'])
 })
 
 t.test('can set ci to latest plus other versions', async t => {
@@ -48,8 +48,8 @@ t.test('can set ci to latest plus other versions', async t => {
   t.equal(pkg.engines.node, '*')
 
   const versions = await getCiJobs(s)
-  t.equal(versions.lint, '22.x')
-  t.strictSame(versions.test, ['6.x', '8.x', '22.x'])
+  t.equal(versions.lint, '26.x')
+  t.strictSame(versions.test, ['6.x', '8.x', '26.x'])
 })
 
 t.test('sort by major', async t => {
@@ -86,6 +86,6 @@ t.test('latest ci versions', async t => {
   t.equal(pkg.engines, undefined)
 
   const versions = await getCiJobs(s)
-  t.equal(versions.lint, '22.x')
-  t.strictSame(versions.test, ['22.x'])
+  t.equal(versions.lint, '26.x')
+  t.strictSame(versions.test, ['26.x'])
 })

--- a/test/apply/node-test-ci.js
+++ b/test/apply/node-test-ci.js
@@ -20,12 +20,10 @@ t.test('CI workflow with node:test does not include tap matcher', async t => {
 
   // Verify conditional test steps for coverage
   t.match(ciWorkflow, /Test \(with coverage on Node >= 24\)/, 'should have test with coverage step for Node >= 24')
-  t.match(ciWorkflow, /Test \(on Node 20 with globbing workaround\)/, 'should have test:node20 step for Node 20')
-  t.match(ciWorkflow, /- name: Test\n\s+if:/, 'should have regular test step for other Node versions')
+  t.match(ciWorkflow, /Test \(without coverage on Node < 24\)/, 'should have test without coverage step for Node < 24')
   t.match(ciWorkflow, "startsWith(matrix.node-version, '24')", 'should check if Node version starts with 24')
-  t.match(ciWorkflow, "startsWith(matrix.node-version, '20')", 'should check if Node version starts with 20')
+  t.match(ciWorkflow, "!startsWith(matrix.node-version, '24')", 'should check if Node version does not start with 24')
   t.match(ciWorkflow, /test:cover/, 'should use test:cover script for Node >= 24')
-  t.match(ciWorkflow, /test:node20/, 'should use test:node20 script for Node 20')
 })
 
 t.test('CI workflow with tap includes tap matcher', async t => {

--- a/test/apply/node-test.js
+++ b/test/apply/node-test.js
@@ -16,7 +16,6 @@ t.test('node:test runner', async t => {
 
   // Verify test scripts are for node:test
   t.equal(pkg.scripts.test, "node --test './test/**/*.js'")
-  t.equal(pkg.scripts['test:node20'], 'node --test test')
   t.equal(
     pkg.scripts['test:cover'],
     "node --test --experimental-test-coverage --test-timeout=3000 --test-coverage-lines=100 --test-coverage-functions=100 --test-coverage-branches=100 './test/**/*.js'",
@@ -53,7 +52,6 @@ t.test('node:test runner with incomplete coverage', async t => {
 
   // Verify test scripts are for node:test
   t.equal(pkg.scripts.test, "node --test './test/**/*.js'")
-  t.equal(pkg.scripts['test:node20'], 'node --test test')
   t.equal(
     pkg.scripts['test:cover'],
     "node --test --experimental-test-coverage --test-timeout=3000 './test/**/*.js'",

--- a/workspace/test-workspace/package.json
+++ b/workspace/test-workspace/package.json
@@ -36,7 +36,7 @@
     "lib/"
   ],
   "engines": {
-    "node": "^18.17.0 || >=20.5.0"
+    "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
   },
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten."


### PR DESCRIPTION
BREAKING CHANGE: removes the test:node20 script and its dedicated CI step now that Node 20 is being deprecated.
